### PR TITLE
feat(config): add defaultPosition in AFK check config

### DIFF
--- a/src/commands/config/ConfigAfkCheck.ts
+++ b/src/commands/config/ConfigAfkCheck.ts
@@ -147,7 +147,8 @@ export class ConfigAfkCheck extends BaseCommand {
                 .map(x => {
                     return {...x};
                 }),
-            vcLimit: section.otherMajorConfig.afkCheckProperties.vcLimit
+            vcLimit: section.otherMajorConfig.afkCheckProperties.vcLimit,
+            defaultPosition: section.otherMajorConfig.afkCheckProperties.defaultPosition
         };
 
         const logChannelButton = new MessageButton()
@@ -186,6 +187,10 @@ export class ConfigAfkCheck extends BaseCommand {
                 .setStyle("PRIMARY"),
             logChannelButton,
             existingVcButton,
+            new MessageButton()
+                .setLabel("Set Default Position")
+                .setCustomId("set_default_pos")
+                .setStyle("PRIMARY"),
             new MessageButton()
                 .setLabel("Set AFK Check Expiration Time")
                 .setCustomId("afk_check_expiration")
@@ -268,6 +273,11 @@ export class ConfigAfkCheck extends BaseCommand {
                 .addField(
                     "AFK Check Expiration Time",
                     StringUtil.codifyString(TimeUtilities.formatDuration(newAfkCheckProps.afkCheckTimeout, true, false)),
+                    true
+                )
+                .addField(
+                    "Default VC Position",
+                    StringUtil.codifyString(newAfkCheckProps.defaultPosition),
                     true
                 )
                 .addField(
@@ -592,6 +602,39 @@ export class ConfigAfkCheck extends BaseCommand {
                         break;
 
                     newAfkCheckProps.prePostAfkCheckPermissions = p.value!;
+                    break;
+                }
+                case "set_default_pos": {
+                    const n = await askInput<number>(
+                        ctx,
+                        botMsg,
+                        {
+                            embeds: [
+                                new MessageEmbed()
+                                    .setAuthor({name: ctx.guild!.name, iconURL: ctx.guild!.iconURL() ?? undefined})
+                                    .setTitle("Default AFK VC Position")
+                                    .setDescription(
+                                        "Here you can set the default raid AFK VC position. This is so that "
+                                        + "staff aren't confused by the position of the newly created channel at the top of "
+                                        + "the list. "
+                                        + "The current value is: " + StringUtil.codifyString(newAfkCheckProps.defaultPosition)
+                                        + "Type a __integer__ that represents the position of the channel. "
+                                        + "If you don't want to set this, press the **Back** button."
+                                    )
+                            ]
+                        },
+                        m => {
+                            const num = Number.parseInt(m.content, 10);
+                            return Number.isNaN(num) ? null : num;
+                        }
+                    );
+
+                    if (typeof n === "undefined" || typeof n !== "number") {
+                        await this.dispose(ctx, botMsg);
+                        return;
+                    }
+
+                    newAfkCheckProps.defaultPosition = n;
                     break;
                 }
                 case "config_gen_afk": {

--- a/src/definitions/DungeonRaidInterfaces.ts
+++ b/src/definitions/DungeonRaidInterfaces.ts
@@ -508,7 +508,7 @@ export interface IAfkCheckProperties {
      * 
      * @type {number}
      */
-     defaultPosition: number;
+    defaultPosition: number;
 }
 
 /**

--- a/src/definitions/DungeonRaidInterfaces.ts
+++ b/src/definitions/DungeonRaidInterfaces.ts
@@ -502,6 +502,13 @@ export interface IAfkCheckProperties {
      * @type {boolean}
      */
     createLogChannel: boolean;
+    
+    /**
+     * Default position for the voice channel to avoid confusing staff.
+     * 
+     * @type {number}
+     */
+     defaultPosition: number;
 }
 
 /**

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -884,7 +884,7 @@ export class RaidInstance {
         if (!vc) return;
 
         if (!this._oldVcPerms) {
-            vc.setPosition(0).then();
+            vc.setPosition(this._raidSection.otherMajorConfig.afkCheckProperties.defaultPosition ?? 0).then();
         }
 
         this._raidVc = vc as VoiceChannel;

--- a/src/managers/MongoManager.ts
+++ b/src/managers/MongoManager.ts
@@ -487,7 +487,8 @@ export namespace MongoManager {
                 afkCheckTimeout: 30 * 60 * 1000,
                 afkCheckPermissions: generalAfkCheckPerms,
                 prePostAfkCheckPermissions: prePostAfkCheckPerms,
-                allowedDungeons: DUNGEON_DATA.map(x => x.codeName)
+                allowedDungeons: DUNGEON_DATA.map(x => x.codeName),
+                defaultPosition: 0
             }
         };
     }


### PR DESCRIPTION
- adds a `defaultPosition` to AFK check config, allowing staff to configure default voice channel position for the raid channel. closes #59
- input could be handled better and check if a user inputs a channel (then adding 1 to the position) though. 
