### PR TITLE
refactor(logging): adding tons of logging for errors and rate-limits

### DIFF
--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -9,6 +9,7 @@ import {
     Interaction,
     Message, PartialGuildMember,
     PartialMessage,
+    RateLimitData,
     ThreadChannel,
     VoiceState
 } from "discord.js";
@@ -18,6 +19,7 @@ import * as Cmds from "./commands";
 import {
     onChannelDeleteEvent,
     onErrorEvent,
+    onRatelimitEvent,
     onGuildCreateEvent,
     onGuildMemberAdd,
     onGuildMemberUpdate,
@@ -276,6 +278,7 @@ export class Bot {
         this._bot.on("voiceStateUpdate", async (o: VoiceState, n: VoiceState) => onVoiceStateEvent(o, n));
         this._bot.on("messageCreate", async (m: Message) => onMessageEvent(m));
         this._bot.on("error", async (e: Error) => onErrorEvent(e));
+        this._bot.on("rateLimit", async (r: RateLimitData) => onRatelimitEvent(r));
         this._bot.on("threadUpdate", async (o: ThreadChannel, n: ThreadChannel) => onThreadArchiveEvent(o, n));
         this._bot.on("channelDelete", async (c: DMChannel | GuildChannel) => onChannelDeleteEvent(c));
         this._bot.on("messageDelete", async (m: Message | PartialMessage) => onMessageDeleteEvent(m));

--- a/src/commands/config/ConfigAfkCheck.ts
+++ b/src/commands/config/ConfigAfkCheck.ts
@@ -117,7 +117,7 @@ export class ConfigAfkCheck extends BaseCommand {
         });
 
         if (!selected || !selected.isSelectMenu()) {
-            this.dispose(ctx, botMsg).catch();
+            this.dispose(ctx, botMsg);
             return;
         }
 

--- a/src/events/ErrorEvent.ts
+++ b/src/events/ErrorEvent.ts
@@ -1,10 +1,13 @@
 import { StringBuilder } from "../utilities/StringBuilder";
 import { TimeUtilities } from "../utilities/TimeUtilities";
+import { Logger } from "../utilities/Logger";
+
+const LOGGER: Logger = new Logger(__filename, false);
 
 export async function onErrorEvent(error: Error): Promise<void> {
-    console.error(
+    LOGGER.error(
         new StringBuilder()
-            .append(`[${TimeUtilities.getDateTime()}] ${error.name}`)
+            .append(`${error.name}`)
             .appendLine(2)
             .append(`\t${error.message}`)
             .appendLine(2)

--- a/src/events/ErrorEvent.ts
+++ b/src/events/ErrorEvent.ts
@@ -1,5 +1,4 @@
 import { StringBuilder } from "../utilities/StringBuilder";
-import { TimeUtilities } from "../utilities/TimeUtilities";
 import { Logger } from "../utilities/Logger";
 
 const LOGGER: Logger = new Logger(__filename, false);

--- a/src/events/InteractionEvent.ts
+++ b/src/events/InteractionEvent.ts
@@ -14,6 +14,9 @@ import { MessageConstants } from "../constants/MessageConstants";
 import { StringBuilder } from "../utilities/StringBuilder";
 import { ModmailManager } from "../managers/ModmailManager";
 import { ButtonConstants } from "../constants/ButtonConstants";
+import { Logger } from "../utilities/Logger";
+
+const LOGGER: Logger = new Logger(__filename, false);
 
 /**
  * Acknowledges a slash command.
@@ -215,7 +218,7 @@ export async function onInteractionEvent(interaction: Interaction): Promise<void
         .find(x => x.manualVerifyMsgId === message.id && x.manualVerifyChannelId === channel.id);
 
     if (manualVerifyChannels) {
-        interaction.deferUpdate().catch();
+        interaction.deferUpdate().catch(LOGGER.error);
         VerifyManager.acknowledgeManualVerifyRes(manualVerifyChannels, resolvedMember, interaction.customId, message)
             .then();
         return;
@@ -245,7 +248,7 @@ export async function onInteractionEvent(interaction: Interaction): Promise<void
 
     // Check modmail
     if (channel.id === guildDoc.channels.modmailChannelId) {
-        interaction.deferUpdate().catch();
+        interaction.deferUpdate().catch(LOGGER.error);
         if (!(interaction.message instanceof Message) || interaction.message.embeds.length === 0) {
             return;
         }

--- a/src/events/RatelimitEvent.ts
+++ b/src/events/RatelimitEvent.ts
@@ -1,0 +1,22 @@
+import { StringBuilder } from "../utilities/StringBuilder";
+import { Logger } from "../utilities/Logger";
+import { RateLimitData } from "discord.js";
+
+const LOGGER: Logger = new Logger(__filename, false);
+
+// {https://discord.js.org/#/docs/discord.js/stable/typedef/RateLimitData}
+export async function onRatelimitEvent(ratelimitData: RateLimitData): Promise<void> {
+    LOGGER.debug(
+        new StringBuilder()
+            .append(`Ratelimit hit: ${ratelimitData.path}/${ratelimitData.route}`)
+            .appendLine()
+            .append(`\tTimeout until next allowed request: ${ratelimitData.timeout}`)
+            .appendLine()
+            .append(`\tMaximum number of requests: ${ratelimitData.limit}`)
+            .appendLine()
+            .append(`\tGlobal ratelimit: ${ratelimitData.global}`)
+            .appendLine()
+            .append("=====================================")
+            .toString()
+    );
+}

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -3,6 +3,7 @@ export * from "./InteractionEvent";
 export * from "./ReadyEvent";
 export * from "./VoiceStateEvent";
 export * from "./ErrorEvent";
+export * from "./RatelimitEvent";
 export * from "./MessageEvent";
 export * from "./ThreadUpdateEvent";
 export * from "./ChannelDeleteEvent";

--- a/src/instances/HeadcountInstance.ts
+++ b/src/instances/HeadcountInstance.ts
@@ -1008,8 +1008,8 @@ export class HeadcountInstance {
         this._intervalsAreRunning = true;
         LOGGER.info(`${this._instanceInfo} Starting all intervals`);
 
-        this.updateControlPanel().catch();
-        this.updateHeadcountPanel().catch();
+        this.updateControlPanel().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
+        this.updateHeadcountPanel().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
 
         return true;
     }
@@ -1043,8 +1043,8 @@ export class HeadcountInstance {
 
         const delayUpdate = this.delay(this._intervalDelay);
 
-        await Promise.all([editMessage, delayUpdate]).catch();
-        this.updateControlPanel().catch();
+        await Promise.all([editMessage, delayUpdate]).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
+        this.updateControlPanel().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
     }
 
     /**
@@ -1068,8 +1068,8 @@ export class HeadcountInstance {
         });
         const delayUpdate = this.delay(this._intervalDelay);
 
-        await Promise.all([editMessage, delayUpdate]).catch();
-        this.updateHeadcountPanel().catch();
+        await Promise.all([editMessage, delayUpdate]).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
+        this.updateHeadcountPanel().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
     }
 
     /**
@@ -1192,7 +1192,7 @@ export class HeadcountInstance {
                     content: "You are in the process of confirming a reaction. If you accidentally dismissed the"
                         + " confirmation message, you may need to wait 15 seconds before you can try again.",
                     ephemeral: true
-                }).catch();
+                }).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return;
             }
 
@@ -1201,7 +1201,7 @@ export class HeadcountInstance {
                 i.reply({
                     content: "An unknown error occurred.",
                     ephemeral: true
-                }).catch();
+                }).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return;
             }
 
@@ -1214,7 +1214,7 @@ export class HeadcountInstance {
                 i.reply({
                     content: "You have already selected this!",
                     ephemeral: true
-                }).catch();
+                }).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return;
             }
 
@@ -1225,7 +1225,7 @@ export class HeadcountInstance {
                 i.reply({
                     content: "You have indicated that you are interested in joining this raid, if it occurs.",
                     ephemeral: true
-                }).catch();
+                }).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return;
             }
 

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -786,6 +786,7 @@ export class RaidInstance {
             const result = await Bot.AxiosClient.head(url);
             if (result.status > 300) return toReturn;
         } catch (e) {
+            LOGGER.error(e);
             return toReturn;
         }
 
@@ -934,7 +935,7 @@ export class RaidInstance {
             components: [],
         });
 
-        this.logEvent("AFK check has been started.", true).catch();
+        this.logEvent("AFK check has been started.", true).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
         const tempMsg = await this._afkCheckChannel.send({
             content: `${this._raidVc.toString()} will be unlocked in 5 seconds. Prepare to join!`,
         });
@@ -997,7 +998,7 @@ export class RaidInstance {
                 ? `${member.displayName} (${member.id}) has ended the AFK check.`
                 : "The AFK check has been ended automatically.",
             true
-        ).catch();
+        ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
 
         // Update the database so it is clear that we are in raid mode.
         await this.stopAllIntervalsAndCollectors();
@@ -1031,7 +1032,7 @@ export class RaidInstance {
         await this.updateMembersArr();
 
         // End the collector since it's useless. We'll use it again though.
-        this.stopAllIntervalsAndCollectors("AFK Check ended.").catch();
+        this.stopAllIntervalsAndCollectors("AFK Check ended.").catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
 
         // Remove reactions from AFK check.
         await this._afkCheckMsg.reactions.removeAll().catch();
@@ -1042,7 +1043,7 @@ export class RaidInstance {
                 embeds: [this.getControlPanelEmbed()!],
                 components: RaidInstance.CP_RAID_BUTTONS,
             })
-            .catch();
+            .catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
 
         // Edit the afk check panel to include reconnect
         await this._afkCheckMsg
@@ -1057,7 +1058,7 @@ export class RaidInstance {
                         .setStyle("SUCCESS"),
                 ]),
             })
-            .catch();
+            .catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
 
         this.startControlPanelCollector();
         this.startIntervals();
@@ -1189,7 +1190,7 @@ export class RaidInstance {
                     ? `${resolvedMember.displayName} (${resolvedMember.id}) has aborted the AFK check.`
                     : "The AFK check has been aborted automatically.",
                 false
-            ).catch();
+            ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
 
             return;
         }
@@ -1199,10 +1200,10 @@ export class RaidInstance {
                 ? `${resolvedMember.displayName} (${resolvedMember.id}) has ended the raid.`
                 : "The raid has been ended automatically.",
             false
-        ).catch();
+        ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
 
         if (this._raidStatus === RaidStatus.RUN_FINISHED) {
-            this.logRun(memberThatEnded).catch();
+            this.logRun(memberThatEnded).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
         }
 
         // Check feedback channel
@@ -1348,7 +1349,7 @@ export class RaidInstance {
                             embeds: [this.getControlPanelEmbed()!],
                             components: [],
                         })
-                        .catch();
+                        .catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                     return;
                 }
                 await MessageUtilities.tryDelete(this._controlPanelMsg);
@@ -1364,8 +1365,8 @@ export class RaidInstance {
                             embeds: [this.getAfkCheckEmbed()!],
                             components: [],
                         })
-                        .catch();
-                    await this._afkCheckMsg.reactions.removeAll().catch();
+                        .catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
+                    await this._afkCheckMsg.reactions.removeAll().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                     return;
                 }
                 await MessageUtilities.tryDelete(this.afkCheckMsg);
@@ -1919,7 +1920,7 @@ export class RaidInstance {
             this.logEvent(
                 `${EmojiConstants.NITRO_EMOJI} ${member.displayName} (${member.id}) has been added to the VC for being a priority react.`,
                 true
-            ).catch();
+            ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
             return;
         }
 
@@ -1929,7 +1930,7 @@ export class RaidInstance {
                 this.logEvent(
                     `${EmojiConstants.EYES_EMOJI} ${member.displayName} (${member.id}) has left the raid VC.`,
                     true
-                ).catch();
+                ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return;
             }
 
@@ -1938,7 +1939,7 @@ export class RaidInstance {
                 this.logEvent(
                     `${EmojiConstants.GREEN_CHECK_EMOJI} ${member.displayName} (${member.id}) has joined the raid VC.`,
                     true
-                ).catch();
+                ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return;
             }
 
@@ -1948,7 +1949,7 @@ export class RaidInstance {
                     `\tFrom: ${oldState.channel!.name} (${oldState.channelId})\n` +
                     `\tTo: ${newState.channel!.name} (${newState.channelId})`,
                 true
-            ).catch();
+            ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
             return;
         }
 
@@ -1958,7 +1959,7 @@ export class RaidInstance {
             this.logEvent(
                 `${EmojiConstants.MIC_EMOJI} ${member.displayName} (${member.id}) is no longer server muted.`,
                 true
-            ).catch();
+            ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
             return;
         }
 
@@ -1967,7 +1968,7 @@ export class RaidInstance {
             this.logEvent(
                 `${EmojiConstants.MIC_EMOJI} ${member.displayName} (${member.id}) is now server muted.`,
                 true
-            ).catch();
+            ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
             return;
         }
 
@@ -1976,7 +1977,7 @@ export class RaidInstance {
             this.logEvent(
                 `${EmojiConstants.HEADPHONE_EMOJI} ${member.displayName} (${member.id}) is no longer deafened.`,
                 true
-            ).catch();
+            ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
             return;
         }
 
@@ -1985,7 +1986,7 @@ export class RaidInstance {
             this.logEvent(
                 `${EmojiConstants.HEADPHONE_EMOJI} ${member.displayName} (${member.id}) is now deafened.`,
                 true
-            ).catch();
+            ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
             return;
         }
 
@@ -1994,7 +1995,7 @@ export class RaidInstance {
             this.logEvent(
                 `${EmojiConstants.CAM_EMOJI} ${member.displayName} (${member.id}) has turned off video.`,
                 true
-            ).catch();
+            ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
             return;
         }
 
@@ -2003,7 +2004,7 @@ export class RaidInstance {
             this.logEvent(
                 `${EmojiConstants.CAM_EMOJI} ${member.displayName} (${member.id}) has turned on video.`,
                 true
-            ).catch();
+            ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
             return;
         }
 
@@ -2012,7 +2013,7 @@ export class RaidInstance {
             this.logEvent(
                 `${EmojiConstants.TV_EMOJI} ${member.displayName} (${member.id}) has stopped streaming.`,
                 true
-            ).catch();
+            ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
             return;
         }
 
@@ -2021,7 +2022,7 @@ export class RaidInstance {
             this.logEvent(
                 `${EmojiConstants.TV_EMOJI} ${member.displayName} (${member.id}) has started streaming.`,
                 true
-            ).catch();
+            ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
             return;
         }
     }
@@ -2056,7 +2057,7 @@ export class RaidInstance {
             return;
         }
 
-        interaction.deferUpdate().catch();
+        interaction.deferUpdate().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
 
         if (member.voice.channel.id === this._raidVc?.id) return;
 
@@ -2066,7 +2067,7 @@ export class RaidInstance {
         this.logEvent(
             `${EmojiConstants.GREEN_CHECK_EMOJI} ${member.displayName} (${member.id}) has reconnected to the raid VC.`,
             true
-        ).catch();
+        ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
         return;
     }
 
@@ -2232,7 +2233,7 @@ export class RaidInstance {
         if (!this._raidVc || !this._addedToDb || !this._isValid) return false;
 
         this._location = newLoc;
-        this.logEvent(`${EmojiConstants.MAP_EMOJI} Location changed to: ${newLoc}`, true).catch();
+        this.logEvent(`${EmojiConstants.MAP_EMOJI} Location changed to: ${newLoc}`, true).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
 
         // Update the location in the database.
         const res = await MongoManager.updateAndFetchGuildDoc(
@@ -2426,8 +2427,8 @@ export class RaidInstance {
         LOGGER.info(`${this._instanceInfo} Starting all intervals`);
         this._intervalsAreRunning = true;
 
-        this.updateControlPanel().catch();
-        this.updateRaidPanel().catch();
+        this.updateControlPanel().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
+        this.updateRaidPanel().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
 
         return true;
     }
@@ -2464,8 +2465,8 @@ export class RaidInstance {
 
         const delayUpdate = delay(this._intervalDelay);
 
-        await Promise.all([editMessage, delayUpdate]).catch();
-        this.updateControlPanel().catch();
+        await Promise.all([editMessage, delayUpdate]).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
+        this.updateControlPanel().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
     }
 
     /**
@@ -2499,8 +2500,8 @@ export class RaidInstance {
 
         const delayUpdate = delay(this._intervalDelay);
 
-        await Promise.all([editMessage, delayUpdate]).catch();
-        this.updateRaidPanel().catch();
+        await Promise.all([editMessage, delayUpdate]).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
+        this.updateRaidPanel().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
     }
 
     /**
@@ -2528,7 +2529,7 @@ export class RaidInstance {
                         "You are in the process of confirming a reaction. If you accidentally dismissed the" +
                         " confirmation message, you may need to wait 15 seconds before you can try again.",
                     ephemeral: true,
-                }).catch();
+                }).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return;
             }
 
@@ -2537,7 +2538,7 @@ export class RaidInstance {
                 i.reply({
                     content: "An unknown error occurred.",
                     ephemeral: true,
-                }).catch();
+                }).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return;
             }
 
@@ -2552,7 +2553,7 @@ export class RaidInstance {
                 i.reply({
                     content: "In order to indicate your class/gear preference, you need to be in a voice channel.",
                     ephemeral: true,
-                }).catch();
+                }).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return;
             }
 
@@ -2567,7 +2568,7 @@ export class RaidInstance {
                 i.reply({
                     content: "You have already selected this!",
                     ephemeral: true,
-                }).catch();
+                }).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return;
             }
 
@@ -2579,7 +2580,7 @@ export class RaidInstance {
                 i.reply({
                     content: `Sorry, but the maximum number of ${itemDis} has been reached.`,
                     ephemeral: true,
-                }).catch();
+                }).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return;
             }
 
@@ -2685,12 +2686,12 @@ export class RaidInstance {
                     " that they have" +
                     ` ${reactInfo.name} (${reactInfo.type}). Modifiers: \`[${res.react!.modifiers.join(", ")}]\``,
                 true
-            ).catch();
+            ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
 
             if (memberThatResponded.voice.channel) {
                 if (memberThatResponded.voice.channelId === this._raidVc.id) return;
                 LOGGER.info(`${this._instanceInfo} Moving ${memberThatResponded.displayName} into raid VC`);
-                memberThatResponded.voice.setChannel(this._raidVc).catch();
+                memberThatResponded.voice.setChannel(this._raidVc).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return;
             }
 
@@ -2739,7 +2740,7 @@ export class RaidInstance {
                 i.reply({
                     content: "An unknown error occurred. Please try again later.",
                     ephemeral: true,
-                }).catch();
+                }).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return false;
             }
 
@@ -2747,7 +2748,7 @@ export class RaidInstance {
                 i.reply({
                     content: "You need to be in the correct raiding VC to interact with these controls.",
                     ephemeral: true,
-                }).catch();
+                }).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return false;
             }
 
@@ -2866,7 +2867,7 @@ export class RaidInstance {
                     this._afkCheckChannel,
                     `${this._leaderName}'s Raid VC has been locked.`,
                     this._tempAlertDelay
-                ).catch();
+                ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return;
             }
 
@@ -2880,13 +2881,13 @@ export class RaidInstance {
                         content: "Unlocked Raid VC.",
                         ephemeral: true,
                     }),
-                    this.logEvent("Raid VC unlocked.", true).catch(),
+                    this.logEvent("Raid VC unlocked.", true).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`)),
                 ]);
                 sendTemporaryAlert(
                     this._afkCheckChannel,
                     `${this._leaderName}'s Raid VC has been unlocked.`,
                     this._tempAlertDelay
-                ).catch();
+                ).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return;
             }
 
@@ -2923,10 +2924,10 @@ export class RaidInstance {
                 const parseSummary = await RaidInstance.parseScreenshot(res.url, this._raidVc);
                 if (!this._raidVc || !this._isValid) return;
 
-                this.logEvent(`Parse executed by ${i.user.tag} (${i.user.id}). Link: \`${res.url}\``, true).catch();
+                this.logEvent(`Parse executed by ${i.user.tag} (${i.user.id}). Link: \`${res.url}\``, true).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
 
                 if (!parseSummary) {
-                    this.logEvent("Parse failed; the API may not be functioning at this time.", true).catch();
+                    this.logEvent("Parse failed; the API may not be functioning at this time.", true).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
 
                     return;
                 }
@@ -2949,7 +2950,7 @@ export class RaidInstance {
 
         this._controlPanelReactionCollector.on("end", async (_, r) => {
             if (r !== "time") return;
-            this.endRaid(null).catch();
+            this.endRaid(null).catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
         });
 
         return true;
@@ -3016,7 +3017,7 @@ export class RaidInstance {
 
         if (!runStatusRes || runStatusRes.customId === ButtonConstants.CANCEL_LOGGING_ID) {
             // TODO validate this better
-            botMsg.delete().catch();
+            botMsg.delete().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
             return;
         }
 
@@ -3079,7 +3080,7 @@ export class RaidInstance {
             );
 
             if (!memberToPick) {
-                botMsg.delete().catch();
+                botMsg.delete().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return;
             }
 
@@ -3109,7 +3110,7 @@ export class RaidInstance {
                 }
 
                 if (memberToPick.customId === ButtonConstants.CANCEL_LOGGING_ID) {
-                    botMsg.delete().catch();
+                    botMsg.delete().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                     return;
                 }
 
@@ -3194,7 +3195,7 @@ export class RaidInstance {
                 );
 
                 if (!memberToPick) {
-                    botMsg.delete().catch();
+                    botMsg.delete().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                     return;
                 }
 
@@ -3231,7 +3232,7 @@ export class RaidInstance {
                     }
 
                     if (memberToPick.customId === ButtonConstants.CANCEL_LOGGING_ID) {
-                        botMsg.delete().catch();
+                        botMsg.delete().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                         return;
                     }
 
@@ -3299,7 +3300,7 @@ export class RaidInstance {
                     // Images have a height property, non-images don't.
                     const imgAttachment = m.attachments.find((x) => x.height !== null);
                     if (!imgAttachment) {
-                        m.delete().catch();
+                        m.delete().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                         return;
                     }
 
@@ -3309,7 +3310,7 @@ export class RaidInstance {
             );
 
             if (!resObj) {
-                botMsg.delete().catch();
+                botMsg.delete().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 return;
             }
 
@@ -3319,7 +3320,7 @@ export class RaidInstance {
                     return res ? res : null;
                 });
                 LOGGER.info(`${this._instanceInfo} Names found in completion: ${data?.names}`);
-                resObj.delete().catch();
+                resObj.delete().catch(e => LOGGER.error(`${this._instanceInfo} ${e}`));
                 if (data && data.names.length > 0) {
                     for (const memberThatJoined of this._membersThatJoined) {
                         const names = UserManager.getAllNames(memberThatJoined.displayName, true);

--- a/src/managers/PunishmentManager.ts
+++ b/src/managers/PunishmentManager.ts
@@ -556,12 +556,12 @@ export namespace PunishmentManager {
         async function sendLoggingAndNoticeMsg(): Promise<void> {
             // Do we really need to check if there is a description here specifically?
             if (details.sendLogInfo && logChannel && logToChanEmbed.description) {
-                await logChannel.send({ embeds: [logToChanEmbed] }).catch();
+                await logChannel.send({ embeds: [logToChanEmbed] }).catch(LOGGER.error);
             }
 
             // These must have a description or else the default arm was reached.
             if (details.sendNoticeToAffectedUser && toSendToUserEmbed.description && member instanceof GuildMember) {
-                await GlobalFgrUtilities.sendMsg(member, { embeds: [toSendToUserEmbed] }).catch();
+                await GlobalFgrUtilities.sendMsg(member, { embeds: [toSendToUserEmbed] }).catch(LOGGER.error);
             }
         }
 
@@ -1137,7 +1137,7 @@ export namespace SuspensionManager {
         }
 
         // Remove roles and log it
-        await member.roles.remove(info.section.roles.verifiedRoleId).catch();
+        await member.roles.remove(info.section.roles.verifiedRoleId).catch(LOGGER.error);
         const r = await PunishmentManager.logPunishment(member, "SectionSuspend", {
             reason: info.reason,
             duration: info.duration === -1 ? undefined : info.duration,
@@ -1204,7 +1204,7 @@ export namespace SuspensionManager {
 
         if (info.section.properties.giveVerifiedRoleUponUnsuspend
             && GuildFgrUtilities.hasCachedRole(member.guild, info.section.roles.verifiedRoleId)) {
-            await member.roles.add(info.section.roles.verifiedRoleId).catch();
+            await member.roles.add(info.section.roles.verifiedRoleId).catch(LOGGER.error);
         }
 
         const r = await PunishmentManager.logPunishment(member, "SectionUnsuspend", {
@@ -1462,7 +1462,7 @@ export namespace MuteManager {
             MutedMembers.get(member.guild.id)!.push(mutedUserObj);
         }
 
-        await member.roles.add(mutedRole).catch();
+        await member.roles.add(mutedRole).catch(LOGGER.error);
 
         const r = await PunishmentManager.logPunishment(member, "Mute", {
             reason: info.reason,
@@ -1522,7 +1522,7 @@ export namespace MuteManager {
             _queuedDelMutedUsers.enqueue({ ...data, guildId: member.guild.id });
         }
 
-        await member.roles.remove(info.guildDoc.roles.mutedRoleId).catch();
+        await member.roles.remove(info.guildDoc.roles.mutedRoleId).catch(LOGGER.error);
         const r = await PunishmentManager.logPunishment(member, "Unmute", {
             reason: info.reason,
             issuedTime: Date.now(),

--- a/src/managers/QuotaManager.ts
+++ b/src/managers/QuotaManager.ts
@@ -242,7 +242,7 @@ export namespace QuotaManager {
                             `quota_${guild.id}_${roleId}_${Date.now()}.txt`)
                     ]
                 }
-            ).catch();
+            ).catch(LOGGER.error);
 
             if (storageMsg)
                 urlToFile = storageMsg.attachments.first()!.url;
@@ -280,7 +280,7 @@ export namespace QuotaManager {
 
         if (quotaMsg) {
             await quotaMsg.edit({ embeds: [summaryEmbed] });
-            quotaMsg.unpin().catch();
+            quotaMsg.unpin().catch(LOGGER.error);
         }
         else
             await quotaChannel.send({ embeds: [summaryEmbed] });
@@ -296,7 +296,7 @@ export namespace QuotaManager {
                 ]
             });
 
-            newMsg.pin().catch();
+            newMsg.pin().catch(LOGGER.error);
 
             await MongoManager.updateAndFetchGuildDoc({
                 guildId: guild.id,
@@ -857,7 +857,7 @@ export namespace QuotaService {
                         ]
                     });
 
-                    newMsg.pin().catch();
+                    newMsg.pin().catch(LOGGER.error);
 
                     await MongoManager.updateAndFetchGuildDoc({
                         guildId: guild.id,

--- a/src/managers/VerifyManager.ts
+++ b/src/managers/VerifyManager.ts
@@ -37,9 +37,6 @@ import { ButtonConstants } from "../constants/ButtonConstants";
 import { InteractivityManager } from "./InteractivityManager";
 import { ModmailManager } from "./ModmailManager";
 import { CommonRegex } from "../constants/CommonRegex";
-import { Logger } from "../utilities/Logger";
-
-const LOGGER: Logger = new Logger(__filename, false);
 
 export namespace VerifyManager {
     export const NUMBER_OF_STATS: number = 8;
@@ -264,7 +261,7 @@ export namespace VerifyManager {
         );
 
         verifyStartChannel?.send(`[${section.sectionName}] ${member} has started the verification process.`)
-            .catch(LOGGER.error);
+            .catch();
 
         // If we can't open a DM, then don't bother.
         let dmMsg: Message | null = null;
@@ -278,7 +275,7 @@ export namespace VerifyManager {
                 });
 
                 verifyFailChannel?.send(`[${section.sectionName}] ${member} could not be directly messaged.`)
-                    .catch(LOGGER.error);
+                    .catch();
                 return;
             }
         }
@@ -309,7 +306,7 @@ export namespace VerifyManager {
             verifyFail: verifyFailChannel,
             verifyChannel: getVerifiedChannel,
             msg: dmMsg
-        }, i).catch(LOGGER.error);
+        }, i).catch();
     }
 
     /**
@@ -343,7 +340,7 @@ export namespace VerifyManager {
         );
 
         verifyStartChannel?.send(`[Main] ${member} has started the verification process.`)
-            .catch(LOGGER.error);
+            .catch();
 
         // If we can't open a DM, then don't bother.
         const dmMsg = await getInitialMessage(member);
@@ -355,7 +352,7 @@ export namespace VerifyManager {
             });
 
             verifyFailChannel?.send(`[Main] ${member} could not be directly messaged.`)
-                .catch(LOGGER.error);
+                .catch();
             return;
         }
 
@@ -384,7 +381,7 @@ export namespace VerifyManager {
             verifyFail: verifyFailChannel,
             verifyChannel: getVerifiedChannel,
             msg: dmMsg
-        }).catch(LOGGER.error);
+        }).catch();
     }
 
     /**
@@ -424,17 +421,17 @@ export namespace VerifyManager {
             verifKit.verifyFail?.send({
                 content: `[${section.sectionName}] ${member} tried to verify but they are currently under manual `
                     + "verification."
-            }).catch(LOGGER.error);
+            }).catch();
             return;
         }
 
         // This has to be a verification channel so we don't need to double check.
         if (section.isMainSection) {
-            verifyMain(member, guildDoc, verifKit).catch(LOGGER.error);
+            verifyMain(member, guildDoc, verifKit).catch();
             return;
         }
 
-        verifySection(member, section, verifKit, interaction!).catch(LOGGER.error);
+        verifySection(member, section, verifKit, interaction!).catch();
     }
 
     /**
@@ -498,7 +495,7 @@ export namespace VerifyManager {
                         + "account, but they did not select a name within the specified time."
                 });
 
-                verifKit.msg.delete().catch(LOGGER.error);
+                verifKit.msg.delete().catch();
                 return;
             }
 
@@ -513,7 +510,7 @@ export namespace VerifyManager {
                         + "asked to either use an existing name or provide a new name."
                 });
 
-                verifKit.msg.delete().catch(LOGGER.error);
+                verifKit.msg.delete().catch();
                 return;
             }
         }
@@ -566,7 +563,7 @@ export namespace VerifyManager {
                         + "asked to provide a name for verification."
                 });
 
-                verifKit.msg.delete().catch(LOGGER.error);
+                verifKit.msg.delete().catch();
                 return;
             }
 
@@ -601,7 +598,7 @@ export namespace VerifyManager {
                                 + " restart the verification process.")
                             .setFooter({ text: "Verification Process Stopped." })
                     ]
-                }).catch(LOGGER.error);
+                }).catch();
 
                 return;
             }
@@ -776,7 +773,7 @@ export namespace VerifyManager {
 
                 if (!r) {
                     collector.stop();
-                    verifKit.msg?.delete().catch(LOGGER.error);
+                    verifKit.msg?.delete().catch();
 
                     verifKit.verifyFail?.send({
                         content: `[Main] ${member} tried to verify as **\`${nameToVerify}\`**, but something went wrong`
@@ -828,7 +825,7 @@ export namespace VerifyManager {
 
                 if (!r) {
                     collector.stop();
-                    verifKit.msg?.delete().catch(LOGGER.error);
+                    verifKit.msg?.delete().catch();
 
                     verifKit.verifyFail?.send({
                         content: `[Main] ${member} tried to verify as **\`${nameToVerify}\`**, but something went wrong`
@@ -967,7 +964,7 @@ export namespace VerifyManager {
 
                 if (!r) {
                     collector.stop();
-                    verifKit.msg?.delete().catch(LOGGER.error);
+                    verifKit.msg?.delete().catch();
 
                     verifKit.verifyFail?.send({
                         content: `[Main] ${member} tried to verify as **\`${nameToVerify}\`**, but something went wrong`
@@ -1014,10 +1011,10 @@ export namespace VerifyManager {
             }
 
             await Promise.all([
-                verifKit.msg!.edit({ embeds: [finishedEmbed] }).catch(LOGGER.error),
+                verifKit.msg!.edit({ embeds: [finishedEmbed] }).catch(),
                 await member.send({
                     content: "Your verification was successful."
-                }).catch(LOGGER.error),
+                }).catch(),
                 verifKit.verifySuccess?.send({
                     content: `[Main] ${member} has successfully verified as **\`${nameToVerify}\`**.`
                 })
@@ -1041,7 +1038,7 @@ export namespace VerifyManager {
 
         if (!section.otherMajorConfig.verificationProperties.checkRequirements) {
             await Promise.all([
-                member.roles.add(verifiedRole).catch(LOGGER.error),
+                member.roles.add(verifiedRole).catch(),
                 interaction.reply({
                     content: "You have successfully been verified.",
                     ephemeral: true
@@ -1148,7 +1145,7 @@ export namespace VerifyManager {
 
         // Passed requirements.
         await Promise.all([
-            member.roles.add(verifiedRole).catch(LOGGER.error),
+            member.roles.add(verifiedRole).catch(),
             interaction.reply({
                 content: "You have successfully been verified.",
                 ephemeral: true
@@ -1303,7 +1300,7 @@ export namespace VerifyManager {
             components: []
         });
 
-        await sendManualVerifyEmbedAndLog(member, checkRes, verifKit, section).catch(LOGGER.error);
+        await sendManualVerifyEmbedAndLog(member, checkRes, verifKit, section).catch();
     }
 
     /**
@@ -1440,7 +1437,7 @@ export namespace VerifyManager {
                             return;
 
                         const relevantMsg = await GuildFgrUtilities.fetchMessage(channel, x.manualVerifyMsgId);
-                        await relevantMsg?.delete().catch(LOGGER.error);
+                        await relevantMsg?.delete().catch();
                     })
             );
 
@@ -1501,7 +1498,7 @@ export namespace VerifyManager {
                     );
 
                 promises.push(
-                    manualVerifMsg?.delete().catch(LOGGER.error),
+                    manualVerifMsg?.delete().catch(),
                     GlobalFgrUtilities.sendMsg(member, { embeds: [finishedEmbed] }),
                     section.isMainSection
                         ? verifyFailChannel?.send({
@@ -1540,7 +1537,7 @@ export namespace VerifyManager {
                 promises.push(
                     manualVerifMsg?.delete().catch(),
                     GlobalFgrUtilities.sendMsg(member, { embeds: [finishedEmbed] }),
-                    member.roles.add(section.roles.verifiedRoleId).catch(LOGGER.error)
+                    member.roles.add(section.roles.verifiedRoleId).catch()
                 );
 
                 if (section.isMainSection) {

--- a/src/managers/VerifyManager.ts
+++ b/src/managers/VerifyManager.ts
@@ -37,6 +37,9 @@ import { ButtonConstants } from "../constants/ButtonConstants";
 import { InteractivityManager } from "./InteractivityManager";
 import { ModmailManager } from "./ModmailManager";
 import { CommonRegex } from "../constants/CommonRegex";
+import { Logger } from "../utilities/Logger";
+
+const LOGGER: Logger = new Logger(__filename, false);
 
 export namespace VerifyManager {
     export const NUMBER_OF_STATS: number = 8;
@@ -261,7 +264,7 @@ export namespace VerifyManager {
         );
 
         verifyStartChannel?.send(`[${section.sectionName}] ${member} has started the verification process.`)
-            .catch();
+            .catch(LOGGER.error);
 
         // If we can't open a DM, then don't bother.
         let dmMsg: Message | null = null;
@@ -275,7 +278,7 @@ export namespace VerifyManager {
                 });
 
                 verifyFailChannel?.send(`[${section.sectionName}] ${member} could not be directly messaged.`)
-                    .catch();
+                    .catch(LOGGER.error);
                 return;
             }
         }
@@ -306,7 +309,7 @@ export namespace VerifyManager {
             verifyFail: verifyFailChannel,
             verifyChannel: getVerifiedChannel,
             msg: dmMsg
-        }, i).catch();
+        }, i).catch(LOGGER.error);
     }
 
     /**
@@ -340,7 +343,7 @@ export namespace VerifyManager {
         );
 
         verifyStartChannel?.send(`[Main] ${member} has started the verification process.`)
-            .catch();
+            .catch(LOGGER.error);
 
         // If we can't open a DM, then don't bother.
         const dmMsg = await getInitialMessage(member);
@@ -352,7 +355,7 @@ export namespace VerifyManager {
             });
 
             verifyFailChannel?.send(`[Main] ${member} could not be directly messaged.`)
-                .catch();
+                .catch(LOGGER.error);
             return;
         }
 
@@ -381,7 +384,7 @@ export namespace VerifyManager {
             verifyFail: verifyFailChannel,
             verifyChannel: getVerifiedChannel,
             msg: dmMsg
-        }).catch();
+        }).catch(LOGGER.error);
     }
 
     /**
@@ -421,17 +424,17 @@ export namespace VerifyManager {
             verifKit.verifyFail?.send({
                 content: `[${section.sectionName}] ${member} tried to verify but they are currently under manual `
                     + "verification."
-            }).catch();
+            }).catch(LOGGER.error);
             return;
         }
 
         // This has to be a verification channel so we don't need to double check.
         if (section.isMainSection) {
-            verifyMain(member, guildDoc, verifKit).catch();
+            verifyMain(member, guildDoc, verifKit).catch(LOGGER.error);
             return;
         }
 
-        verifySection(member, section, verifKit, interaction!).catch();
+        verifySection(member, section, verifKit, interaction!).catch(LOGGER.error);
     }
 
     /**
@@ -495,7 +498,7 @@ export namespace VerifyManager {
                         + "account, but they did not select a name within the specified time."
                 });
 
-                verifKit.msg.delete().catch();
+                verifKit.msg.delete().catch(LOGGER.error);
                 return;
             }
 
@@ -510,7 +513,7 @@ export namespace VerifyManager {
                         + "asked to either use an existing name or provide a new name."
                 });
 
-                verifKit.msg.delete().catch();
+                verifKit.msg.delete().catch(LOGGER.error);
                 return;
             }
         }
@@ -563,7 +566,7 @@ export namespace VerifyManager {
                         + "asked to provide a name for verification."
                 });
 
-                verifKit.msg.delete().catch();
+                verifKit.msg.delete().catch(LOGGER.error);
                 return;
             }
 
@@ -598,7 +601,7 @@ export namespace VerifyManager {
                                 + " restart the verification process.")
                             .setFooter({ text: "Verification Process Stopped." })
                     ]
-                }).catch();
+                }).catch(LOGGER.error);
 
                 return;
             }
@@ -773,7 +776,7 @@ export namespace VerifyManager {
 
                 if (!r) {
                     collector.stop();
-                    verifKit.msg?.delete().catch();
+                    verifKit.msg?.delete().catch(LOGGER.error);
 
                     verifKit.verifyFail?.send({
                         content: `[Main] ${member} tried to verify as **\`${nameToVerify}\`**, but something went wrong`
@@ -825,7 +828,7 @@ export namespace VerifyManager {
 
                 if (!r) {
                     collector.stop();
-                    verifKit.msg?.delete().catch();
+                    verifKit.msg?.delete().catch(LOGGER.error);
 
                     verifKit.verifyFail?.send({
                         content: `[Main] ${member} tried to verify as **\`${nameToVerify}\`**, but something went wrong`
@@ -964,7 +967,7 @@ export namespace VerifyManager {
 
                 if (!r) {
                     collector.stop();
-                    verifKit.msg?.delete().catch();
+                    verifKit.msg?.delete().catch(LOGGER.error);
 
                     verifKit.verifyFail?.send({
                         content: `[Main] ${member} tried to verify as **\`${nameToVerify}\`**, but something went wrong`
@@ -1011,10 +1014,10 @@ export namespace VerifyManager {
             }
 
             await Promise.all([
-                verifKit.msg!.edit({ embeds: [finishedEmbed] }).catch(),
+                verifKit.msg!.edit({ embeds: [finishedEmbed] }).catch(LOGGER.error),
                 await member.send({
                     content: "Your verification was successful."
-                }).catch(),
+                }).catch(LOGGER.error),
                 verifKit.verifySuccess?.send({
                     content: `[Main] ${member} has successfully verified as **\`${nameToVerify}\`**.`
                 })
@@ -1038,7 +1041,7 @@ export namespace VerifyManager {
 
         if (!section.otherMajorConfig.verificationProperties.checkRequirements) {
             await Promise.all([
-                member.roles.add(verifiedRole).catch(),
+                member.roles.add(verifiedRole).catch(LOGGER.error),
                 interaction.reply({
                     content: "You have successfully been verified.",
                     ephemeral: true
@@ -1145,7 +1148,7 @@ export namespace VerifyManager {
 
         // Passed requirements.
         await Promise.all([
-            member.roles.add(verifiedRole).catch(),
+            member.roles.add(verifiedRole).catch(LOGGER.error),
             interaction.reply({
                 content: "You have successfully been verified.",
                 ephemeral: true
@@ -1300,7 +1303,7 @@ export namespace VerifyManager {
             components: []
         });
 
-        await sendManualVerifyEmbedAndLog(member, checkRes, verifKit, section).catch();
+        await sendManualVerifyEmbedAndLog(member, checkRes, verifKit, section).catch(LOGGER.error);
     }
 
     /**
@@ -1437,7 +1440,7 @@ export namespace VerifyManager {
                             return;
 
                         const relevantMsg = await GuildFgrUtilities.fetchMessage(channel, x.manualVerifyMsgId);
-                        await relevantMsg?.delete().catch();
+                        await relevantMsg?.delete().catch(LOGGER.error);
                     })
             );
 
@@ -1498,7 +1501,7 @@ export namespace VerifyManager {
                     );
 
                 promises.push(
-                    manualVerifMsg?.delete().catch(),
+                    manualVerifMsg?.delete().catch(LOGGER.error),
                     GlobalFgrUtilities.sendMsg(member, { embeds: [finishedEmbed] }),
                     section.isMainSection
                         ? verifyFailChannel?.send({
@@ -1537,7 +1540,7 @@ export namespace VerifyManager {
                 promises.push(
                     manualVerifMsg?.delete().catch(),
                     GlobalFgrUtilities.sendMsg(member, { embeds: [finishedEmbed] }),
-                    member.roles.add(section.roles.verifiedRoleId).catch()
+                    member.roles.add(section.roles.verifiedRoleId).catch(LOGGER.error)
                 );
 
                 if (section.isMainSection) {

--- a/src/utilities/collectors/AdvancedCollector.ts
+++ b/src/utilities/collectors/AdvancedCollector.ts
@@ -24,6 +24,9 @@ import { GuildFgrUtilities } from "../fetch-get-request/GuildFgrUtilities";
 import { EmojiConstants } from "../../constants/EmojiConstants";
 import { GlobalFgrUtilities } from "../fetch-get-request/GlobalFgrUtilities";
 import { StringUtil } from "../StringUtilities";
+import { Logger } from "../Logger";
+
+const LOGGER: Logger = new Logger(__filename, false);
 
 /**
  * A series of helpful collector functions.
@@ -131,7 +134,7 @@ export namespace AdvancedCollector {
 
             msgCollector.on("collect", async (c: Message) => {
                 if (options.deleteResponseMessage)
-                    await c.delete().catch();
+                    await c.delete().catch(LOGGER.error);
 
                 if (cancelFlag && cancelFlag.toLowerCase() === c.content.toLowerCase())
                     return resolve(null);
@@ -148,7 +151,7 @@ export namespace AdvancedCollector {
 
             msgCollector.on("end", (c, r) => {
                 if (options.deleteBaseMsgAfterComplete && botMsg && botMsg.deletable)
-                    botMsg.delete().catch();
+                    botMsg.delete().catch(LOGGER.error);
                 if (r === "time") return resolve(null);
             });
         });
@@ -211,12 +214,13 @@ export namespace AdvancedCollector {
             if (options.acknowledgeImmediately)
                 await returnInteraction.deferUpdate();
         } catch (e) {
+            // check end.reason
             // Ignore the error; this is because the collector timed out.
         } finally {
             if (options.deleteBaseMsgAfterComplete)
-                await botMsg.delete().catch();
+                await botMsg.delete().catch(LOGGER.error);
             else if (options.clearInteractionsAfterComplete && botMsg.editable)
-                await botMsg.edit(MessageUtilities.getMessageOptionsFromMessage(botMsg, [])).catch();
+                await botMsg.edit(MessageUtilities.getMessageOptionsFromMessage(botMsg, [])).catch(LOGGER.error);
         }
 
         return returnInteraction;
@@ -291,9 +295,9 @@ export namespace AdvancedCollector {
                 if (hasCalled) return;
                 hasCalled = true;
                 if (options.deleteBaseMsgAfterComplete && botMsg?.deletable)
-                    botMsg?.delete().catch();
+                    botMsg?.delete().catch(LOGGER.error);
                 else if (options.clearInteractionsAfterComplete && botMsg?.editable)
-                    botMsg?.edit(MessageUtilities.getMessageOptionsFromMessage(botMsg, [])).catch();
+                    botMsg?.edit(MessageUtilities.getMessageOptionsFromMessage(botMsg, [])).catch(LOGGER.error);
                 if (r === "time") return resolve(null);
             }
         });

--- a/src/utilities/fetch-get-request/GlobalFgrUtilities.ts
+++ b/src/utilities/fetch-get-request/GlobalFgrUtilities.ts
@@ -11,6 +11,9 @@ import {
 import { MiscUtilities } from "../MiscUtilities";
 import { Bot } from "../../Bot";
 import { IReactionInfo } from "../../definitions";
+import { Logger } from "../Logger";
+
+const LOGGER: Logger = new Logger(__filename, false);
 
 /**
  * A set of functions that essentially "abstract" away the client methods. This was created so that if discord.js
@@ -28,6 +31,8 @@ export namespace GlobalFgrUtilities {
         try {
             return await targetUser.createDM();
         } catch (e) {
+            // Respond in ephemeral reply if they don't have DMs enabled & tell them
+            LOGGER.error(e);
             return null;
         }
     }
@@ -67,6 +72,7 @@ export namespace GlobalFgrUtilities {
         try {
             return await Bot.BotInstance.client.guilds.fetch(guildId);
         } catch (e) {
+            LOGGER.error(e);
             return null;
         }
     }
@@ -125,6 +131,7 @@ export namespace GlobalFgrUtilities {
         try {
             return Bot.BotInstance.client.users.fetch(targetId);
         } catch (e) {
+            LOGGER.error(e);
             return null;
         }
     }
@@ -143,6 +150,7 @@ export namespace GlobalFgrUtilities {
         try {
             return await channel.send(msgOptions);
         } catch (e) {
+            LOGGER.error(e);
             return null;
         }
     }
@@ -157,6 +165,7 @@ export namespace GlobalFgrUtilities {
         try {
             return func();
         } catch (e) {
+            LOGGER.error(e);
             return null;
         }
     }
@@ -171,6 +180,7 @@ export namespace GlobalFgrUtilities {
         try {
             return await func();
         } catch (e) {
+            LOGGER.error(e);
             return null;
         }
     }

--- a/src/utilities/fetch-get-request/GuildFgrUtilities.ts
+++ b/src/utilities/fetch-get-request/GuildFgrUtilities.ts
@@ -229,6 +229,7 @@ export namespace GuildFgrUtilities {
         try {
             return await guild.members.fetch(targetId);
         } catch (e) {
+            // Only possible if the ID is incorrect/if they aren't in the guild
             return null;
         }
     }
@@ -250,6 +251,7 @@ export namespace GuildFgrUtilities {
         try {
             return !!(await channel.messages.fetch(msgId));
         } catch (e) {
+            // Only possible if the message doesn't exist in the channel
             return false;
         }
     }
@@ -271,6 +273,7 @@ export namespace GuildFgrUtilities {
         try {
             return await channel.messages.fetch(msgId);
         } catch (e) {
+            // Only possible if the message doesn't exist in the channel
             return null;
         }
     }
@@ -287,6 +290,7 @@ export namespace GuildFgrUtilities {
         try {
             return guild.roles.fetch(roleId as Snowflake);
         } catch (e) {
+            // Only possible if the role doesn't exist/ID is wrong
             return null;
         }
     }


### PR DESCRIPTION

# 
Creates a logger in most files that can throw an error and logs it. This __will__ spam the shit out of logs, but it will be very useful for finding the reason for bugs (i.e. crashes, headcounts randomly not working, unexpected behavior.)
#
Previous code simply catches errors and doesn't allow for the `errorEvent` or any internal node events to log info about the error that was caught.
```js
try {...}
catch (e) {
    return;
}
```

Thus, the PR proposes changing simply *catching and returning* to logging pretty much everything that can return an error, most situations like this:
```js
try {...}
catch (e) {
    LOGGER.error(e);
    return;
}
```
or this:
```js
.catch(LOGGER.error)
```
#
This also implements a simple debug log for the `ratelimitEvent` passed by discord.js for anything that the bot may encounter, such as rapidly reacting to messages in channels, sending messages too fast, moving too many people out of a channel, making too many channels in a short amount of time, a lot more.