### PR TITLE
feat: ping rls when all keys have a react

### DIFF
--- a/src/instances/HeadcountInstance.ts
+++ b/src/instances/HeadcountInstance.ts
@@ -1111,7 +1111,7 @@ export class HeadcountInstance {
         // Filter reacts so that we have every key and there is at least one react
         const keyReacts = this._pplWithEarlyLoc.filter((v, k) => k !== "interested" && v.length !== 0);
         const completeSize = this._pplWithEarlyLoc.size - 1; // Ignore the interested key that appears on every headcount
-        if (keyReacts.size === completeSize && !this._leaderAlerted) {
+        if (keyReacts.size !== 0 && keyReacts.size === completeSize && !this._leaderAlerted) {
             this._leaderAlerted = true;
             this._controlPanelChannel.send({
                 content: `${this._memberInit} All key reacts have at least one react!`

--- a/src/instances/HeadcountInstance.ts
+++ b/src/instances/HeadcountInstance.ts
@@ -129,6 +129,8 @@ export class HeadcountInstance {
     private readonly _leaderName: string;
     // Whether this has already been added to the database
     private _addedToDb: boolean = false;
+    // If the leader has already been pinged when the keys are ready
+    private _leaderAlerted: boolean = false;
 
     // Anyone that is currently confirming their reaction with the bot.
     // This is so we don't have double reactions
@@ -1109,7 +1111,8 @@ export class HeadcountInstance {
         // Filter reacts so that we have every key and there is at least one react
         const keyReacts = this._pplWithEarlyLoc.filter((v, k) => k !== "interested" && v.length !== 0);
         const completeSize = this._pplWithEarlyLoc.size - 1; // Ignore the interested key that appears on every headcount
-        if (keyReacts.size === completeSize) {
+        if (keyReacts.size === completeSize && !this._leaderAlerted) {
+            this._leaderAlerted = true;
             this._controlPanelChannel.send({
                 content: `${this._memberInit} All key reacts have at least one react!`
             });

--- a/src/instances/HeadcountInstance.ts
+++ b/src/instances/HeadcountInstance.ts
@@ -1106,6 +1106,15 @@ export class HeadcountInstance {
 
         prop.push({ member: member, modifiers: modifiers });
 
+        // Filter reacts so that we have every key and there is at least one react
+        const keyReacts = this._pplWithEarlyLoc.filter((v, k) => k !== "interested" && v.length !== 0);
+        const completeSize = this._pplWithEarlyLoc.size - 1; // Ignore the interested key that appears on every headcount
+        if (keyReacts.size === completeSize) {
+            this._controlPanelChannel.send({
+                content: `${this._memberInit} All key reacts have at least one react!`
+            });
+        }
+
         if (!addToDb || !this._addedToDb || !this._headcountMsg)
             return true;
 


### PR DESCRIPTION
headcounts always have interested button + key react buttons
so when receiving a call to addKeyReact, check if we have someone in each of the categories and the length isn't 0, then compare to the original size -1 for the interested button for headcounts that have multiple reacts