### PR TITLE
More fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,10 +27,6 @@
                 "ignoreComments": true // No option to match comments with expected indent and it looks really ugly
             }
         ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
         "quotes": [
             "error", // Ignores when template literals are actually used (`${something}` vs `something`)
             "double"

--- a/src/instances/Common.ts
+++ b/src/instances/Common.ts
@@ -32,6 +32,7 @@ import { DefinedRole } from "../definitions/Types";
 import { MiscUtilities } from "../utilities/MiscUtilities";
 import { LoggerManager } from "../managers/LoggerManager";
 import { Logger } from "../utilities/Logger";
+import { EmojiConstants } from "../constants/EmojiConstants";
 
 const LOGGER: Logger = new Logger(__filename, false);
 
@@ -125,7 +126,7 @@ export async function confirmReaction(
             .setCustomId(cancelModId);
 
         const sb = new StringBuilder()
-            .append(`You pressed the ${itemDisplay} button.`);
+            .append(`You pressed the ${itemDisplay} button. `);
         const buttons: BaseMessageComponent[] = [];
 
         if (modifiers.length > 0) {
@@ -138,7 +139,8 @@ export async function confirmReaction(
                 .append("- If you have **multiple** keys, please specify the modifiers for **one** of your keys and")
                 .append(" message the raid leader the modifiers of the remaining key.").appendLine()
                 .append("- If you do not have any modifiers, please press the **No Modifier** button.").appendLine()
-                .append("- If you did not mean to press this button, please press the **Cancel** button.");
+                .append("- If you did not mean to press this button, please press the **Cancel** button.")
+                .appendLine(2);
 
             buttons.push(
                 selectMenu,
@@ -161,7 +163,8 @@ export async function confirmReaction(
                 .append(" this raid, and that your key has at least one modifier.")
                 .appendLine()
                 .append("- Press the **Cancel** button to cancel this process (e.g. if you accidentally pressed this")
-                .append(" button.");
+                .append(" button.")
+                .appendLine(2);
 
             buttons.push(
                 new MessageButton()
@@ -174,6 +177,9 @@ export async function confirmReaction(
                     .setCustomId(noneListedId)
             );
         }
+
+        sb.append(`${EmojiConstants.WARNING_EMOJI} **Please note that once you confirm your reaction, you will not`
+            + " be able to unreact.**");
 
         buttons.push(cancelButton);
         await interaction.reply({
@@ -271,7 +277,7 @@ export async function confirmReaction(
             }
             buttonsToUse.push(accidentButton);
             buttonsToUse.push(cancelButton);
-            
+
             await interaction.editReply({
                 content: `What **level** is the **${modifier.modifierName}** modifier? If you want to cancel this,`
                     + " press the **Cancel** button. If you mistakenly selected this modifier, press the"
@@ -421,6 +427,9 @@ export async function confirmReaction(
             .appendLine(2)
             .append("You have **15** seconds to select an option. Failure to respond will result in an ")
             .append("automatic **no**.")
+            .appendLine(2)
+            .append(`${EmojiConstants.WARNING_EMOJI} **Please note that once you confirm your reaction, you will not`
+                + " be able to unreact.**")
             .toString();
     }
 
@@ -619,8 +628,11 @@ export function getItemDisplay(reactInfo: ReactionInfoMore): string {
  * @param {Guild} guild The guild.
  * @returns {CollectorFilter} The collector filter to use.
  */
-export function controlPanelCollectorFilter(guildDoc: IGuildInfo, section: ISectionInfo,
-                                            guild: Guild): CollectorFilter<[MessageComponentInteraction]> {
+export function controlPanelCollectorFilter(
+    guildDoc: IGuildInfo, 
+    section: ISectionInfo, 
+    guild: Guild
+): CollectorFilter<[MessageComponentInteraction]> {
     return async (i) => {
         if (i.user.bot) return false;
 

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -2118,7 +2118,7 @@ export class RaidInstance {
             for (const { member, modifiers } of members) {
                 sb.append(`\t> ${member.displayName} (${member.user.tag}, ${member.id})`).appendLine();
                 if (modifiers.length > 0) {
-                    sb.append(`\t> Modifiers: ${modifiers.join(", ")}`).appendLine();
+                    sb.append(`\t\t> Modifiers: [${modifiers.join(", ")}]`).appendLine();
                 }
             }
         }

--- a/src/managers/QuotaManager.ts
+++ b/src/managers/QuotaManager.ts
@@ -871,12 +871,19 @@ export namespace QuotaService {
                     continue;
                 }
 
-                await quotaMsg.edit({
-                    embeds: [
-                        (await QuotaManager.getQuotaLeaderboardEmbed(guild, guildDoc, quotaInfo))!
-                    ]
-                });
-                LOGGER.debug(`Finished updating quota for role: ${role.name}`);
+                // Lots of errors here specifically indicating that "AbortError: The user aborted a request."
+                // Throwing a try/catch here should be a sufficient, albeit scuffed, fix for this problem.
+                try {
+                    await quotaMsg.edit({
+                        embeds: [
+                            (await QuotaManager.getQuotaLeaderboardEmbed(guild, guildDoc, quotaInfo))!
+                        ]
+                    });
+                    LOGGER.debug(`Finished updating quota for role: ${role.name}`);
+                }
+                catch (e) {
+                    LOGGER.debug(`Unable to update quota embed for role "${role.name}" in server "${guild.name}"\n${e}`);
+                }
             }
             LOGGER.debug(`Finished updating quota for guild: ${guild.name}`);
         }

--- a/src/managers/QuotaManager.ts
+++ b/src/managers/QuotaManager.ts
@@ -892,11 +892,16 @@ export namespace QuotaService {
 
                 // Lots of errors here specifically indicating that "AbortError: The user aborted a request."
                 // Throwing a try/catch here should be a sufficient, albeit scuffed, fix for this problem.
+                const newEmbed = await QuotaManager.getQuotaLeaderboardEmbed(guild, guildDoc, quotaInfo)!;
+                if (!newEmbed) {
+                    LOGGER.debug(`An unknown error occurred when trying to update quota for "${role.name}"`
+                        + ` in server "${guild.name}": embed creation failed`);
+                    continue;
+                }
+
                 try {
                     await quotaMsg.edit({
-                        embeds: [
-                            (await QuotaManager.getQuotaLeaderboardEmbed(guild, guildDoc, quotaInfo))!
-                        ]
+                        embeds: [newEmbed]
                     });
                     LOGGER.debug(`Finished updating quota for role: ${role.name}`);
                 }


### PR DESCRIPTION
Possibly fixed issue #131: Specifically, the issue was that the bot encountered an `AbortError: The user aborted a request.` error when trying to edit the quota leaderboard embed. Because the `run` function (responsible for periodically updating the quota leaderboards) needs to be called again after running, an error like the one I just said will prevent said function from calling itself, resulting in what appears to be quotas hanging. 

Fixed issue #149.

Fixed issue #180.

Acknowledged, but did not add, #115: I don't really think it's worthwhile to add an unreact feature. I added a warning -- in bold -- that clearly states that you won't be able to unreact. If someone really needs to leave, they can just message a leader.

Removed the style rule `linebreak-style` since I don't think it's all that important (although feel free to correct me) and it keeps giving me thousands of style errors on my side that I have to keep correcting (which would result in essentially all files being edited).