### PR TITLE
[1.2.1] Verification hotfix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tooga-booga",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A simple Discord bot for Realm of the Mad God servers, designed for verification and raid management. ",
   "main": "index.js",
   "scripts": {

--- a/src/commands/config/ConfigChannels.ts
+++ b/src/commands/config/ConfigChannels.ts
@@ -287,7 +287,16 @@ export class ConfigChannels extends BaseCommand implements IConfigCommand {
 
     /** @inheritDoc */
     public async entry(ctx: ICommandContext, botMsg: Message | null): Promise<void> {
-        const entryRes = await entryFunction(ctx, botMsg);
+        const entryRes = await entryFunction(ctx, botMsg, {
+            embeds: [
+                MessageUtilities.generateBlankEmbed(ctx.member!, "RANDOM")
+                    .setTitle("Select Section")
+                    .setDescription(new StringBuilder("Please select the appropriate section.")
+                        .appendLine().appendLine()
+                        .append("If you wish to cancel this process, please press the `Cancel` button.").toString())
+                    .setFooter({ text: "Section Selector" })
+            ]
+        });
 
         if (!entryRes) {
             await this.dispose(ctx, botMsg);

--- a/src/commands/config/ConfigRoles.ts
+++ b/src/commands/config/ConfigRoles.ts
@@ -299,7 +299,17 @@ export class ConfigRoles extends BaseCommand implements IConfigCommand {
 
     /** @inheritDoc */
     public async entry(ctx: ICommandContext, botMsg: Message | null): Promise<void> {
-        const entryRes = await entryFunction(ctx, botMsg);
+        const entryRes = await entryFunction(ctx, botMsg, {
+            embeds: [
+                MessageUtilities.generateBlankEmbed(ctx.member!, "RANDOM")
+                    .setTitle("Select Section")
+                    .setDescription(new StringBuilder("Please select the appropriate section.")
+                        .appendLine().appendLine()
+                        .append("If you wish to cancel this process, please press the `Cancel` button.").toString())
+                    .setFooter({ text: "Section Selector" })
+            ]
+        });
+        
         if (!entryRes) {
             await this.dispose(ctx, botMsg);
             return;

--- a/src/commands/staff/EditName.ts
+++ b/src/commands/staff/EditName.ts
@@ -193,11 +193,7 @@ export class EditName extends BaseCommand {
                 if (proposedName.length <= 32) {
                     // Then change it.
                     const res = await GlobalFgrUtilities.tryExecuteAsync(async () => {
-                        await member.setNickname(
-                            proposedName === member.user.username
-                                ? proposedName + "."
-                                : proposedName
-                        );
+                        await member.setNickname(UserManager.getNameForNickname(member, proposedName));
                         return true;
                     });
 
@@ -352,11 +348,7 @@ export class EditName extends BaseCommand {
             // and the proposed name doesn't exceed the nickname character limit...
             if (newName.length <= 32) {
                 const res = await GlobalFgrUtilities.tryExecuteAsync(async () => {
-                    await member.setNickname(
-                        newName === member.user.username
-                            ? newName + "."
-                            : newName
-                    );
+                    await member.setNickname(UserManager.getNameForNickname(member, newName));
                     return true;
                 });
                 updatedName = !!res;

--- a/src/commands/staff/ManualVerifyMain.ts
+++ b/src/commands/staff/ManualVerifyMain.ts
@@ -187,7 +187,7 @@ export class ManualVerifyMain extends BaseCommand {
         await verifySuccessChannel?.send({
             content: `\`[Main]\` ${resMember.member} has been manually verified as **\`${ignToVerifyWith}\`** by`
                 + ` ${ctx.user}.`,
-            allowedMentions: {}
+            allowedMentions: { roles: [], users: [] }
         });
 
         if (!useAlreadyVerifiedIgn) {

--- a/src/commands/staff/ManualVerifyMain.ts
+++ b/src/commands/staff/ManualVerifyMain.ts
@@ -181,7 +181,9 @@ export class ManualVerifyMain extends BaseCommand {
 
         await GlobalFgrUtilities.tryExecuteAsync(async () => {
             await resMember.member.setNickname(UserManager.getNameForNickname(resMember.member, ignToVerifyWith));
-
+        });
+        await GlobalFgrUtilities.tryExecuteAsync(async () => {
+            await resMember.member.roles.add(verifiedRole);
         });
 
         await verifySuccessChannel?.send({
@@ -211,10 +213,6 @@ export class ManualVerifyMain extends BaseCommand {
         }
 
         await GlobalFgrUtilities.sendMsg(resMember.member, { embeds: [finishedEmbed] });
-
-        await GlobalFgrUtilities.tryExecuteAsync(async () => {
-            return await resMember.member.roles.add(verifiedRole);
-        });
 
         // Finally, remove manual verification entry if it exists
         const mVerifyEntry = ctx.guildDoc!.manualVerificationEntries

--- a/src/commands/staff/ManualVerifyMain.ts
+++ b/src/commands/staff/ManualVerifyMain.ts
@@ -180,12 +180,14 @@ export class ManualVerifyMain extends BaseCommand {
         );
 
         await GlobalFgrUtilities.tryExecuteAsync(async () => {
-            await resMember.member.setNickname(ignToVerifyWith, "Manually verified.");
+            await resMember.member.setNickname(UserManager.getNameForNickname(resMember.member, ignToVerifyWith));
+
         });
 
         await verifySuccessChannel?.send({
-            content: `[Main] ${resMember.member} has been manually verified as **\`${ignToVerifyWith}\`** by`
-                + ` ${ctx.user}.`
+            content: `\`[Main]\` ${resMember.member} has been manually verified as **\`${ignToVerifyWith}\`** by`
+                + ` ${ctx.user}.`,
+            allowedMentions: {}
         });
 
         if (!useAlreadyVerifiedIgn) {

--- a/src/commands/staff/ManualVerifySection.ts
+++ b/src/commands/staff/ManualVerifySection.ts
@@ -177,7 +177,8 @@ export class ManualVerifySection extends BaseCommand {
         });
 
         await secVerifSuccessChannel?.send({
-            content: `[${section.sectionName}] ${resMember.member} has been manually verified by ${ctx.user}.`
+            content: `\`[${section.sectionName}]\` ${resMember.member} has been manually verified by ${ctx.user}.`,
+            allowedMentions: {}
         });
 
         const sVerifyEntry = ctx.guildDoc!.manualVerificationEntries

--- a/src/commands/staff/ManualVerifySection.ts
+++ b/src/commands/staff/ManualVerifySection.ts
@@ -178,7 +178,7 @@ export class ManualVerifySection extends BaseCommand {
 
         await secVerifSuccessChannel?.send({
             content: `\`[${section.sectionName}]\` ${resMember.member} has been manually verified by ${ctx.user}.`,
-            allowedMentions: {}
+            allowedMentions: { roles: [], users: [] }
         });
 
         const sVerifyEntry = ctx.guildDoc!.manualVerificationEntries

--- a/src/commands/staff/RemoveName.ts
+++ b/src/commands/staff/RemoveName.ts
@@ -201,12 +201,7 @@ export class RemoveName extends BaseCommand {
 
             const res = await GlobalFgrUtilities.tryExecuteAsync(async () => {
                 if (newName.length > 0) {
-                    await member.setNickname(
-                        newName === member.user.username
-                            ? newName + "."
-                            : newName
-                    );
-
+                    await member.setNickname(UserManager.getNameForNickname(member, newName));
                     return true;
                 }
                 // Here, we permit setting their nickname to their username if no names exist.

--- a/src/managers/UserManager.ts
+++ b/src/managers/UserManager.ts
@@ -171,6 +171,22 @@ export namespace UserManager {
     }
 
     /**
+     * Gets the name that should be used for the member's nickname on Discord. This will account for the possibility
+     * that the member's username is the same as the proposed IGN.
+     * @param member The member.
+     * @param ign The in-game name.
+     * @returns The in-game name to use for the member's nickname.
+     */
+    export function getNameForNickname(member: GuildMember, ign: string): string {
+        let r = ign;
+        if (member.user.username === ign) {
+            r += ".";
+        }
+
+        return r;
+    }
+
+    /**
      * Gets this person's prefixes. For example, if the name was "!test" then this would return '!'
      * @param {string} rawName The name.
      * @returns {string} The prefixes, if any.

--- a/src/managers/VerifyManager.ts
+++ b/src/managers/VerifyManager.ts
@@ -563,7 +563,7 @@ export namespace VerifyManager {
                         new MessageEmbed(baseEmbed)
                             .setTitle(`**${instance.member.guild.name}**: Guild Verification Error.`)
                             .setDescription(
-                                "Oops, an error occurred when trying to reach your RealmEye profile's basis data."
+                                "Oops, an error occurred when trying to reach your RealmEye profile's basic data."
                                 + " This error is usually caused by one of several things."
                             )
                             .addField(

--- a/src/managers/VerifyManager.ts
+++ b/src/managers/VerifyManager.ts
@@ -849,10 +849,11 @@ export namespace VerifyManager {
      */
     async function verifySection(interaction: MessageComponentInteraction, instance: IVerificationInstance): Promise<void> {
         if (!instance.section.otherMajorConfig.verificationProperties.checkRequirements) {
+            await GlobalFgrUtilities.tryExecuteAsync(async () => {
+                await instance.member.roles.add(instance.section.roles.verifiedRoleId);
+            });
+
             await Promise.all([
-                GlobalFgrUtilities.tryExecuteAsync(async () => {
-                    await instance.member.roles.add(instance.guildDoc.roles.verifiedRoleId);
-                }),
                 instance.verifySuccessChannel?.send({
                     content: `\`[${instance.section.sectionName}]\` ${instance.member} has successfully been verified`
                         + " in this section.",
@@ -955,13 +956,17 @@ export namespace VerifyManager {
             await GlobalFgrUtilities.tryExecuteAsync(async () => {
                 await instance.member.roles.add(instance.section.roles.verifiedRoleId);
             });
-            await interaction.editReply({
-                content: "You have successfully been verified."
-            });
-            await instance.verifySuccessChannel?.send({
-                content: `[${instance.section.sectionName}] ${instance.member} has successfully been verified in this section.`,
-                allowedMentions: { roles: [], users: [] }
-            });
+
+            await Promise.all([
+                instance.verifySuccessChannel?.send({
+                    content: `\`[${instance.section.sectionName}]\` ${instance.member} has successfully been verified`
+                        + " in this section.",
+                    allowedMentions: { roles: [], users: [] }
+                }),
+                interaction.editReply({
+                    content: "You have been verified successfully."
+                })
+            ]);
         }
 
         InteractivityManager.IN_VERIFICATION.delete(instance.member.id);

--- a/src/managers/VerifyManager.ts
+++ b/src/managers/VerifyManager.ts
@@ -603,7 +603,6 @@ export namespace VerifyManager {
             }
 
             // Is the verification code in their profile?
-            /*
             if (!generalData.description.some(x => x.includes(verificationCode))) {
                 await MessageUtilities.tryEdit(msg, {
                     embeds: [
@@ -627,7 +626,7 @@ export namespace VerifyManager {
                 });
 
                 return;
-            }*/
+            }
 
             // Get name history for this user.
             const nameHistory = await GlobalFgrUtilities.tryExecuteAsync(async () => {

--- a/src/managers/VerifyManager.ts
+++ b/src/managers/VerifyManager.ts
@@ -295,7 +295,8 @@ export namespace VerifyManager {
             if (!r) {
                 instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} was asked to select a name previously associated with `
-                        + "their Discord account, something went wrong when trying to edit the base embed message."
+                        + "their Discord account, something went wrong when trying to edit the base embed message.",
+                    allowedMentions: {}
                 });
 
                 InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
@@ -316,7 +317,8 @@ export namespace VerifyManager {
             if (!selected) {
                 instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} was asked to select a name previously associated with `
-                        + "their Discord account, but they did not select a name within the specified time."
+                        + "their Discord account, but they did not select a name within the specified time.",
+                    allowedMentions: {}
                 });
 
                 InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
@@ -332,7 +334,8 @@ export namespace VerifyManager {
             else if (selected.customId === ButtonConstants.CANCEL_ID) {
                 instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} has stopped the verification process. This occurred when `
-                        + "the person was asked to either use an existing name or provide a new name."
+                        + "the person was asked to either use an existing name or provide a new name.",
+                    allowedMentions: {}
                 });
 
                 InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
@@ -363,7 +366,8 @@ export namespace VerifyManager {
             if (!r) {
                 instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} was asked to select for a name to verify with, but `
-                        + "something went wrong when trying to edit the base embed message."
+                        + "something went wrong when trying to edit the base embed message.",
+                    allowedMentions: {}
                 });
 
                 InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
@@ -393,7 +397,8 @@ export namespace VerifyManager {
             // Once again, if we get no response, then we can just quit.
             if (!selected) {
                 instance.verifyFailChannel?.send({
-                    content: `\`[Main]\` ${instance.member} was asked for a name, but they did not respond in time.`
+                    content: `\`[Main]\` ${instance.member} was asked for a name, but they did not respond in time.`,
+                    allowedMentions: {}
                 });
 
                 InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
@@ -405,7 +410,8 @@ export namespace VerifyManager {
             if (selected instanceof MessageComponentInteraction) {
                 instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} has stopped the verification process when asked to type`
-                        + " their name."
+                        + " their name.",
+                    allowedMentions: {}
                 });
 
                 InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
@@ -432,7 +438,8 @@ export namespace VerifyManager {
                 const idsRegistered = matchedUserDocs.map(x => x.currentDiscordId).join(", ");
                 instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} tried to verify with the name, **\`${selected}\`**, `
-                        + `but this name has already been registered by the following Discord ID(s): ${idsRegistered}.`
+                        + `but this name has already been registered by the following Discord ID(s): ${idsRegistered}.`,
+                    allowedMentions: {}
                 });
 
                 await MessageUtilities.tryEdit(msg, {
@@ -445,8 +452,6 @@ export namespace VerifyManager {
                                 + " Please resolve this issue by messaging a staff member for assistance. If you want"
                                 + " to verify with another in-game name, please restart the verification process."
                             )
-                            .setFooter({ text: "This process will expire by" })
-                            .setTimestamp(Date.now() + 2 * 60 * 1000)
                     ],
                     components: []
                 });
@@ -464,7 +469,8 @@ export namespace VerifyManager {
         const verificationCode = StringUtil.generateRandomString(20);
         instance.verifyStepChannel?.send({
             content: `\`[Main]\` ${instance.member} will be trying to verify as **\`${nameToVerify}\`**. Their`
-                + ` verification code is **\`${verificationCode}\`**.`
+                + ` verification code is **\`${verificationCode}\`**.`,
+            allowedMentions: {}
         }).catch();
 
         const timeStarted = Date.now();
@@ -512,7 +518,8 @@ export namespace VerifyManager {
                 });
 
                 await instance.verifyFailChannel?.send({
-                    content: `\`[Main]\` ${instance.member} has canceled the verification process.`
+                    content: `\`[Main]\` ${instance.member} has canceled the verification process.`,
+                    allowedMentions: {}
                 });
 
                 await i.editReply({
@@ -539,7 +546,8 @@ export namespace VerifyManager {
 
             await instance.verifyStepChannel?.send({
                 content: `\`[Main]\` ${instance.member} is now waiting for the bot to finish checking their IGN,`
-                    + ` \`${nameToVerify}\`.`
+                    + ` \`${nameToVerify}\`.`,
+                allowedMentions: {}
             });
 
             // Request general profile data.
@@ -581,7 +589,8 @@ export namespace VerifyManager {
 
                 await instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} tried to verify as **\`${nameToVerify}\`**, but their profile`
-                        + " is either private or the API is not available."
+                        + " is either private or the API is not available.",
+                    allowedMentions: {}
                 });
 
                 await i.editReply({
@@ -611,8 +620,9 @@ export namespace VerifyManager {
                 });
 
                 instance.verifyFailChannel?.send({
-                    content: `[Main] ${instance.member} tried to verify as **\`${nameToVerify}\`**, but the`
-                        + ` verification code, \`${verificationCode}\`, was not found in their description.`
+                    content: `\`[Main]\` ${instance.member} tried to verify as **\`${nameToVerify}\`**, but the`
+                        + ` verification code, \`${verificationCode}\`, was not found in their description.`,
+                    allowedMentions: {}
                 });
 
                 return;
@@ -639,8 +649,9 @@ export namespace VerifyManager {
                 });
 
                 instance.verifyFailChannel?.send({
-                    content: `[Main] ${instance.member} tried to verify as **\`${nameToVerify}\`**, but an unknown error `
-                        + "occurred when trying to reach their profile's **name history**."
+                    content: `\`[Main]\` ${instance.member} tried to verify as **\`${nameToVerify}\`**, but an unknown error `
+                        + "occurred when trying to reach their profile's **name history**.",
+                    allowedMentions: {}
                 });
 
                 return;
@@ -689,9 +700,10 @@ export namespace VerifyManager {
                 });
 
                 await instance.verifyFailChannel?.send({
-                    content: `[Main] ${instance.member} tried to verify as **\`${nameToVerify}\`**, but they are`
+                    content: `\`[Main]\` ${instance.member} tried to verify as **\`${nameToVerify}\`**, but they are`
                         + ` blacklisted from this server under the name: \`${blInfo.realmName.ign}\`. The`
-                        + ` corresponding Moderation ID is \`${blInfo.actionId}\`.`
+                        + ` corresponding Moderation ID is \`${blInfo.actionId}\`.`,
+                    allowedMentions: {}
                 });
 
                 await i.editReply({
@@ -736,7 +748,8 @@ export namespace VerifyManager {
                 await instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} tried to verify as **\`${nameToVerify}\`**, but they failed`
                         + " to meet one or more major requirements. The requirements are:\n"
-                        + failedReqs.map(x => `- ${x.log}`).join("\n")
+                        + failedReqs.map(x => `- ${x.log}`).join("\n"),
+                    allowedMentions: {}
                 });
 
                 await i.editReply({
@@ -788,7 +801,10 @@ export namespace VerifyManager {
                 await instance.member.roles.add(instance.guildDoc.roles.verifiedRoleId);
             });
             await GlobalFgrUtilities.tryExecuteAsync(async () => {
-                await instance.member.setNickname(generalData.name, "Verified in the main section successfully.");
+                await instance.member.setNickname(
+                    UserManager.getNameForNickname(instance.member, generalData.name), 
+                    "Verified in the main section successfully."
+                );
             });
 
             // Let them know that it's done
@@ -814,7 +830,8 @@ export namespace VerifyManager {
                     content: "Your verification was successful."
                 }),
                 instance.verifySuccessChannel?.send({
-                    content: `[Main] ${instance.member} has successfully verified as **\`${nameToVerify}\`**.`
+                    content: `\`[Main]\` ${instance.member} has successfully verified as **\`${nameToVerify}\`**.`,
+                    allowedMentions: {}
                 })
             ]);
 
@@ -836,8 +853,9 @@ export namespace VerifyManager {
                     await instance.member.roles.add(instance.guildDoc.roles.verifiedRoleId);
                 }),
                 instance.verifySuccessChannel?.send({
-                    content: `[${instance.section.sectionName}] ${instance.member} has successfully been verified`
-                        + " in this section."
+                    content: `\`[${instance.section.sectionName}]\` ${instance.member} has successfully been verified`
+                        + " in this section.",
+                    allowedMentions: {}
                 }),
                 interaction.editReply({
                     content: "You have been verified successfully."
@@ -860,8 +878,9 @@ export namespace VerifyManager {
                             + " member for assistance."
                     }),
                     instance.verifyFailChannel?.send({
-                        content: `[${instance.section.sectionName}] ${instance.member} does not have a name registered with`
-                            + " the bot, or a valid nickname, and thus cannot verify in this section."
+                        content: `\`[${instance.section.sectionName}]\` ${instance.member} does not have a name registered with`
+                            + " the bot, or a valid nickname, and thus cannot verify in this section.",
+                        allowedMentions: {}
                     })
                 ]);
 
@@ -886,9 +905,10 @@ export namespace VerifyManager {
                         + " profile is **public** (anyone can see it).",
                 }),
                 instance.verifyFailChannel?.send({
-                    content: `[${instance.section.sectionName}] ${instance.member} tried to verify as **\`${nameToUse}\`**,`
+                    content: `\`[${instance.section.sectionName}]\` ${instance.member} tried to verify as **\`${nameToUse}\`**,`
                         + " but an unknown error occurred when trying to reach their RealmEye profile's basic data"
-                        + ` (https://www.realmeye.com/player/${nameToUse}). Is the profile private?`
+                        + ` (https://www.realmeye.com/player/${nameToUse}). Is the profile private?`,
+                    allowedMentions: {}
                 })
             ]);
 
@@ -905,9 +925,10 @@ export namespace VerifyManager {
                         + checkRes.taIssues.map(x => `- **${x.key}**: ${x.value}`).join("\n"),
                 }),
                 instance.verifyFailChannel?.send({
-                    content: `[${instance.section.sectionName}] ${instance.member} tried to verify as **\`${nameToUse}\`**,`
-                    + " but there were several minor issues with the person's profile. These issues are listed below:\n"
-                    + checkRes.taIssues.map(x => `- **[${x.key}]** ${x.log}`).join("\n")
+                    content: `\`[${instance.section.sectionName}]\` ${instance.member} tried to verify as **\`${nameToUse}\`**,`
+                        + " but there were several minor issues with the person's profile. These issues are listed below:\n"
+                        + checkRes.taIssues.map(x => `- **[${x.key}]** ${x.log}`).join("\n"),
+                    allowedMentions: {}
                 })
             ]);
         }
@@ -919,9 +940,10 @@ export namespace VerifyManager {
                         + checkRes.fatalIssues.map(x => `- **${x.key}**: ${x.value}`).join("\n"),
                 }),
                 instance.verifyFailChannel?.send({
-                    content: `[${instance.section.sectionName}] ${instance.member} tried to verify as **\`${nameToUse}\`**,`
+                    content: `\`[${instance.section.sectionName}]\` ${instance.member} tried to verify as **\`${nameToUse}\`**,`
                         + " but there were several fatal issues with the person's profile. These issues are listed below:\n"
-                        + checkRes.fatalIssues.map(x => `- **[${x.key}]** ${x.log}`).join("\n")
+                        + checkRes.fatalIssues.map(x => `- **[${x.key}]** ${x.log}`).join("\n"),
+                    allowedMentions: {}
                 })
             ]);
         }
@@ -936,7 +958,8 @@ export namespace VerifyManager {
                 content: "You have successfully been verified."
             });
             await instance.verifySuccessChannel?.send({
-                content: `[${instance.section.sectionName}] ${instance.member} has successfully been verified in this section.`
+                content: `[${instance.section.sectionName}] ${instance.member} has successfully been verified in this section.`,
+                allowedMentions: {}
             });
         }
 
@@ -1010,12 +1033,13 @@ export namespace VerifyManager {
             });
         }
 
-        const secGuildDisplayLog = instance.section.isMainSection ? "[Main]" : `[${instance.section.sectionName}]`;
+        const secGuildDisplayLog = "`" + (instance.section.isMainSection ? "[Main]" : `[${instance.section.sectionName}]`) + "`";
         if (!m) {
             instance.verifyFailChannel?.send({
                 content: `${secGuildDisplayLog} ${instance.member} tried to verify as **\`${checkRes.name}\`**, but failed the`
                     + " requirements. The manual verification request could not be sent to the user due to an issue on the"
-                    + " user's side."
+                    + " user's side.",
+                allowedMentions: {}
             });
 
             return;
@@ -1024,7 +1048,8 @@ export namespace VerifyManager {
         instance.verifyStepChannel?.send({
             content: `${secGuildDisplayLog} ${instance.member} tried to verify as **\`${checkRes.name}\`**, but there were several `
                 + "minor issues with the person's profile. The user is currently being asked if they want"
-                + " to get manually verified. The outstanding issues are listed below:\n" + logStr
+                + " to get manually verified. The outstanding issues are listed below:\n" + logStr,
+            allowedMentions: {}
         });
 
         const selected = await AdvancedCollector.startInteractionEphemeralCollector({
@@ -1037,7 +1062,8 @@ export namespace VerifyManager {
         if (!selected) {
             instance.verifyFailChannel?.send({
                 content: `${secGuildDisplayLog} ${instance.member} tried to verify as **\`${checkRes.name}\`**, and was in the process`
-                    + " of accepting/denying manual verification, but did not respond in time to the question."
+                    + " of accepting/denying manual verification, but did not respond in time to the question.",
+                allowedMentions: {}
             });
 
             if (m instanceof Message) {
@@ -1055,7 +1081,8 @@ export namespace VerifyManager {
         if (selected.customId === noId) {
             instance.verifyFailChannel?.send({
                 content: `${secGuildDisplayLog} ${instance.member} tried to verify as **\`${checkRes.name}\`**, was in the process`
-                    + " of accepting/denying manual verification, and chose to **deny** manual verification."
+                    + " of accepting/denying manual verification, and chose to **deny** manual verification.",
+                allowedMentions: {}
             });
 
             const rejectEmbed = MessageUtilities.generateBlankEmbed(instance.member.guild, "RED")
@@ -1087,7 +1114,8 @@ export namespace VerifyManager {
         instance.verifyStepChannel?.send({
             content: `${secGuildDisplayLog} ${instance.member} tried to verify as **\`${checkRes.name}\`**, was in the process`
                 + " of accepting/denying manual verification, and chose to **accept** manual verification. Please review their"
-                + " manual verification request."
+                + " manual verification request.",
+            allowedMentions: {}
         });
 
         const okEmbed = MessageUtilities.generateBlankEmbed(instance.member.guild, "RED")
@@ -1314,21 +1342,27 @@ export namespace VerifyManager {
                 });
 
                 if (section.isMainSection) {
+                    await GlobalFgrUtilities.tryExecuteAsync(async () => {
+                        await member.setNickname(
+                            UserManager.getNameForNickname(member, entry.ign), 
+                            "Verified in the main section successfully."
+                        );
+                    });
+                    await MongoManager.addIdNameToIdNameCollection(member, entry.ign);    
+                                    
                     promises.push(
-                        MongoManager.addIdNameToIdNameCollection(member, entry.ign),
-                        GlobalFgrUtilities.tryExecuteAsync(async () => {
-                            await member.setNickname(entry.ign, "Verified in the main section successfully.");
-                        }),
                         verifySuccessChannel?.send({
-                            content: `[Main] ${member} has successfully verified as **\`${entry.ign}\`**`
-                                + ` by ${mod}.`
+                            content: `\`[Main]\` ${member} has successfully verified as **\`${entry.ign}\`**`
+                                + ` by ${mod}.`,
+                            allowedMentions: {}
                         })
                     );
                 }
                 else {
                     promises.push(
                         verifySuccessChannel?.send({
-                            content: `[${section.sectionName}] ${member} has been manually verified by ${mod}.`
+                            content: `\`[${section.sectionName}]\` ${member} has been manually verified by ${mod}.`,
+                            allowedMentions: {}
                         })
                     );
                 }
@@ -1352,15 +1386,14 @@ export namespace VerifyManager {
                                 )
                         ] 
                     }),
-                    section.isMainSection
-                        ? verifyFailChannel?.send({
-                            content: `[Main] ${member} has tried to verify as **\`${entry.ign}\`**, but`
+                    verifyFailChannel?.send({
+                        content: section.isMainSection
+                            ? `\`[Main]\` ${member} has tried to verify as **\`${entry.ign}\`**, but`
                                 + ` their manual verification request was __denied__ by ${mod}.`
-                        })
-                        : verifyFailChannel?.send({
-                            content: `[${section.sectionName}] ${member} has tried to get manually verified, but`
-                                + ` was __denied__ manual verification by ${mod}.`
-                        })
+                            : `\`[${section.sectionName}]\` ${member} has tried to get manually verified, but`
+                                + ` was __denied__ manual verification by ${mod}.`,
+                        allowedMentions: {}
+                    })
                 );
 
                 break;

--- a/src/managers/VerifyManager.ts
+++ b/src/managers/VerifyManager.ts
@@ -783,15 +783,13 @@ export namespace VerifyManager {
             }
 
             // Otherwise, they must have passed.
-            await Promise.all([
-                MongoManager.addIdNameToIdNameCollection(instance.member, generalData.name),
-                GlobalFgrUtilities.tryExecuteAsync(async () => {
-                    await instance.member.roles.add(instance.guildDoc.roles.verifiedRoleId);
-                }),
-                GlobalFgrUtilities.tryExecuteAsync(async () => {
-                    await instance.member.setNickname(generalData.name, "Verified in the main section successfully.");
-                })
-            ]);
+            await MongoManager.addIdNameToIdNameCollection(instance.member, generalData.name);
+            await GlobalFgrUtilities.tryExecuteAsync(async () => {
+                await instance.member.roles.add(instance.guildDoc.roles.verifiedRoleId);
+            });
+            await GlobalFgrUtilities.tryExecuteAsync(async () => {
+                await instance.member.setNickname(generalData.name, "Verified in the main section successfully.");
+            });
 
             // Let them know that it's done
             const successEmbed = MessageUtilities.generateBlankEmbed(instance.member.guild, "GREEN")
@@ -931,17 +929,15 @@ export namespace VerifyManager {
             await handleManualVerification(instance, checkRes, interaction);
         }
         else {
-            await Promise.all([
-                GlobalFgrUtilities.tryExecuteAsync(async () => {
-                    await instance.member.roles.add(instance.section.roles.verifiedRoleId);
-                }),
-                interaction.editReply({
-                    content: "You have successfully been verified."
-                }),
-                instance.verifySuccessChannel?.send({
-                    content: `[${instance.section.sectionName}] ${instance.member} has successfully been verified in this section.`
-                })
-            ]);
+            await GlobalFgrUtilities.tryExecuteAsync(async () => {
+                await instance.member.roles.add(instance.section.roles.verifiedRoleId);
+            });
+            await interaction.editReply({
+                content: "You have successfully been verified."
+            });
+            await instance.verifySuccessChannel?.send({
+                content: `[${instance.section.sectionName}] ${instance.member} has successfully been verified in this section.`
+            });
         }
 
         InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
@@ -1312,12 +1308,10 @@ export namespace VerifyManager {
                     );
                 }
 
-                promises.push(
-                    GlobalFgrUtilities.sendMsg(member, { embeds: [successEmbed] }),
-                    GlobalFgrUtilities.tryExecuteAsync(async () => {
-                        await member.roles.add(section!.roles.verifiedRoleId);
-                    })
-                );
+                await GlobalFgrUtilities.sendMsg(member, { embeds: [successEmbed] });
+                await GlobalFgrUtilities.tryExecuteAsync(async () => {
+                    await member.roles.add(section!.roles.verifiedRoleId);
+                });
 
                 if (section.isMainSection) {
                     promises.push(

--- a/src/managers/VerifyManager.ts
+++ b/src/managers/VerifyManager.ts
@@ -296,7 +296,7 @@ export namespace VerifyManager {
                 instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} was asked to select a name previously associated with `
                         + "their Discord account, something went wrong when trying to edit the base embed message.",
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 });
 
                 InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
@@ -318,7 +318,7 @@ export namespace VerifyManager {
                 instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} was asked to select a name previously associated with `
                         + "their Discord account, but they did not select a name within the specified time.",
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 });
 
                 InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
@@ -335,7 +335,7 @@ export namespace VerifyManager {
                 instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} has stopped the verification process. This occurred when `
                         + "the person was asked to either use an existing name or provide a new name.",
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 });
 
                 InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
@@ -367,7 +367,7 @@ export namespace VerifyManager {
                 instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} was asked to select for a name to verify with, but `
                         + "something went wrong when trying to edit the base embed message.",
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 });
 
                 InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
@@ -398,7 +398,7 @@ export namespace VerifyManager {
             if (!selected) {
                 instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} was asked for a name, but they did not respond in time.`,
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 });
 
                 InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
@@ -411,7 +411,7 @@ export namespace VerifyManager {
                 instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} has stopped the verification process when asked to type`
                         + " their name.",
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 });
 
                 InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
@@ -439,7 +439,7 @@ export namespace VerifyManager {
                 instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} tried to verify with the name, **\`${selected}\`**, `
                         + `but this name has already been registered by the following Discord ID(s): ${idsRegistered}.`,
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 });
 
                 await MessageUtilities.tryEdit(msg, {
@@ -470,7 +470,7 @@ export namespace VerifyManager {
         instance.verifyStepChannel?.send({
             content: `\`[Main]\` ${instance.member} will be trying to verify as **\`${nameToVerify}\`**. Their`
                 + ` verification code is **\`${verificationCode}\`**.`,
-            allowedMentions: {}
+            allowedMentions: { roles: [], users: [] }
         }).catch();
 
         const timeStarted = Date.now();
@@ -519,7 +519,7 @@ export namespace VerifyManager {
 
                 await instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} has canceled the verification process.`,
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 });
 
                 await i.editReply({
@@ -547,7 +547,7 @@ export namespace VerifyManager {
             await instance.verifyStepChannel?.send({
                 content: `\`[Main]\` ${instance.member} is now waiting for the bot to finish checking their IGN,`
                     + ` \`${nameToVerify}\`.`,
-                allowedMentions: {}
+                allowedMentions: { roles: [], users: [] }
             });
 
             // Request general profile data.
@@ -590,7 +590,7 @@ export namespace VerifyManager {
                 await instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} tried to verify as **\`${nameToVerify}\`**, but their profile`
                         + " is either private or the API is not available.",
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 });
 
                 await i.editReply({
@@ -603,6 +603,7 @@ export namespace VerifyManager {
             }
 
             // Is the verification code in their profile?
+            /*
             if (!generalData.description.some(x => x.includes(verificationCode))) {
                 await MessageUtilities.tryEdit(msg, {
                     embeds: [
@@ -622,11 +623,11 @@ export namespace VerifyManager {
                 instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} tried to verify as **\`${nameToVerify}\`**, but the`
                         + ` verification code, \`${verificationCode}\`, was not found in their description.`,
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 });
 
                 return;
-            }
+            }*/
 
             // Get name history for this user.
             const nameHistory = await GlobalFgrUtilities.tryExecuteAsync(async () => {
@@ -651,7 +652,7 @@ export namespace VerifyManager {
                 instance.verifyFailChannel?.send({
                     content: `\`[Main]\` ${instance.member} tried to verify as **\`${nameToVerify}\`**, but an unknown error `
                         + "occurred when trying to reach their profile's **name history**.",
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 });
 
                 return;
@@ -703,7 +704,7 @@ export namespace VerifyManager {
                     content: `\`[Main]\` ${instance.member} tried to verify as **\`${nameToVerify}\`**, but they are`
                         + ` blacklisted from this server under the name: \`${blInfo.realmName.ign}\`. The`
                         + ` corresponding Moderation ID is \`${blInfo.actionId}\`.`,
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 });
 
                 await i.editReply({
@@ -749,7 +750,7 @@ export namespace VerifyManager {
                     content: `\`[Main]\` ${instance.member} tried to verify as **\`${nameToVerify}\`**, but they failed`
                         + " to meet one or more major requirements. The requirements are:\n"
                         + failedReqs.map(x => `- ${x.log}`).join("\n"),
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 });
 
                 await i.editReply({
@@ -831,7 +832,7 @@ export namespace VerifyManager {
                 }),
                 instance.verifySuccessChannel?.send({
                     content: `\`[Main]\` ${instance.member} has successfully verified as **\`${nameToVerify}\`**.`,
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 })
             ]);
 
@@ -855,7 +856,7 @@ export namespace VerifyManager {
                 instance.verifySuccessChannel?.send({
                     content: `\`[${instance.section.sectionName}]\` ${instance.member} has successfully been verified`
                         + " in this section.",
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 }),
                 interaction.editReply({
                     content: "You have been verified successfully."
@@ -880,7 +881,7 @@ export namespace VerifyManager {
                     instance.verifyFailChannel?.send({
                         content: `\`[${instance.section.sectionName}]\` ${instance.member} does not have a name registered with`
                             + " the bot, or a valid nickname, and thus cannot verify in this section.",
-                        allowedMentions: {}
+                        allowedMentions: { roles: [], users: [] }
                     })
                 ]);
 
@@ -908,7 +909,7 @@ export namespace VerifyManager {
                     content: `\`[${instance.section.sectionName}]\` ${instance.member} tried to verify as **\`${nameToUse}\`**,`
                         + " but an unknown error occurred when trying to reach their RealmEye profile's basic data"
                         + ` (https://www.realmeye.com/player/${nameToUse}). Is the profile private?`,
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 })
             ]);
 
@@ -928,7 +929,7 @@ export namespace VerifyManager {
                     content: `\`[${instance.section.sectionName}]\` ${instance.member} tried to verify as **\`${nameToUse}\`**,`
                         + " but there were several minor issues with the person's profile. These issues are listed below:\n"
                         + checkRes.taIssues.map(x => `- **[${x.key}]** ${x.log}`).join("\n"),
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 })
             ]);
         }
@@ -943,7 +944,7 @@ export namespace VerifyManager {
                     content: `\`[${instance.section.sectionName}]\` ${instance.member} tried to verify as **\`${nameToUse}\`**,`
                         + " but there were several fatal issues with the person's profile. These issues are listed below:\n"
                         + checkRes.fatalIssues.map(x => `- **[${x.key}]** ${x.log}`).join("\n"),
-                    allowedMentions: {}
+                    allowedMentions: { roles: [], users: [] }
                 })
             ]);
         }
@@ -959,7 +960,7 @@ export namespace VerifyManager {
             });
             await instance.verifySuccessChannel?.send({
                 content: `[${instance.section.sectionName}] ${instance.member} has successfully been verified in this section.`,
-                allowedMentions: {}
+                allowedMentions: { roles: [], users: [] }
             });
         }
 
@@ -1039,7 +1040,7 @@ export namespace VerifyManager {
                 content: `${secGuildDisplayLog} ${instance.member} tried to verify as **\`${checkRes.name}\`**, but failed the`
                     + " requirements. The manual verification request could not be sent to the user due to an issue on the"
                     + " user's side.",
-                allowedMentions: {}
+                allowedMentions: { roles: [], users: [] }
             });
 
             return;
@@ -1049,7 +1050,7 @@ export namespace VerifyManager {
             content: `${secGuildDisplayLog} ${instance.member} tried to verify as **\`${checkRes.name}\`**, but there were several `
                 + "minor issues with the person's profile. The user is currently being asked if they want"
                 + " to get manually verified. The outstanding issues are listed below:\n" + logStr,
-            allowedMentions: {}
+            allowedMentions: { roles: [], users: [] }
         });
 
         const selected = await AdvancedCollector.startInteractionEphemeralCollector({
@@ -1063,7 +1064,7 @@ export namespace VerifyManager {
             instance.verifyFailChannel?.send({
                 content: `${secGuildDisplayLog} ${instance.member} tried to verify as **\`${checkRes.name}\`**, and was in the process`
                     + " of accepting/denying manual verification, but did not respond in time to the question.",
-                allowedMentions: {}
+                allowedMentions: { roles: [], users: [] }
             });
 
             if (m instanceof Message) {
@@ -1082,7 +1083,7 @@ export namespace VerifyManager {
             instance.verifyFailChannel?.send({
                 content: `${secGuildDisplayLog} ${instance.member} tried to verify as **\`${checkRes.name}\`**, was in the process`
                     + " of accepting/denying manual verification, and chose to **deny** manual verification.",
-                allowedMentions: {}
+                allowedMentions: { roles: [], users: [] }
             });
 
             const rejectEmbed = MessageUtilities.generateBlankEmbed(instance.member.guild, "RED")
@@ -1115,7 +1116,7 @@ export namespace VerifyManager {
             content: `${secGuildDisplayLog} ${instance.member} tried to verify as **\`${checkRes.name}\`**, was in the process`
                 + " of accepting/denying manual verification, and chose to **accept** manual verification. Please review their"
                 + " manual verification request.",
-            allowedMentions: {}
+            allowedMentions: { roles: [], users: [] }
         });
 
         const okEmbed = MessageUtilities.generateBlankEmbed(instance.member.guild, "RED")
@@ -1354,7 +1355,7 @@ export namespace VerifyManager {
                         verifySuccessChannel?.send({
                             content: `\`[Main]\` ${member} has successfully verified as **\`${entry.ign}\`**`
                                 + ` by ${mod}.`,
-                            allowedMentions: {}
+                            allowedMentions: { roles: [], users: [] }
                         })
                     );
                 }
@@ -1362,7 +1363,7 @@ export namespace VerifyManager {
                     promises.push(
                         verifySuccessChannel?.send({
                             content: `\`[${section.sectionName}]\` ${member} has been manually verified by ${mod}.`,
-                            allowedMentions: {}
+                            allowedMentions: { roles: [], users: [] }
                         })
                     );
                 }
@@ -1392,7 +1393,7 @@ export namespace VerifyManager {
                                 + ` their manual verification request was __denied__ by ${mod}.`
                             : `\`[${section.sectionName}]\` ${member} has tried to get manually verified, but`
                                 + ` was __denied__ manual verification by ${mod}.`,
-                        allowedMentions: {}
+                        allowedMentions: { roles: [], users: [] }
                     })
                 );
 
@@ -1461,8 +1462,8 @@ export namespace VerifyManager {
 
         // Check guild. Failure to pass these tests will result in a fail.
         if (verifReq.guild.checkThis) {
-            if (verifReq.guild.guildName.checkThis
-                && resp.guild.toLowerCase() !== verifReq.guild.guildName.name.toLowerCase()) {
+            if (verifReq.guild.guildName.checkThis 
+                && (!resp.guild || resp.guild.toLowerCase() !== verifReq.guild.guildName.name.toLowerCase())) {
                 const guildInDisplay = `**\`${resp.guild}\`**`;
                 const guildNeededDisplay = `**\`${verifReq.guild.guildName.name}\`**`;
                 result.fatalIssues.push({
@@ -1482,7 +1483,16 @@ export namespace VerifyManager {
                 const rankHasDisplay = `**\`${resp.guildRank}\`**`;
                 const rankNeedDisplay = `**\`${verifReq.guild.guildRank.minRank}\`**`;
 
-                if (verifReq.guild.guildRank.exact) {
+                if (!resp.guildRank) {
+                    result.fatalIssues.push({
+                        key: "Invalid Guild Rank",
+                        value: "A guild rank could not be found on your profile.",
+                        log: "A guild rank could not be found on the user's profile"
+                    });
+                    result.conclusion = "FAIL";
+                    return result;
+                }
+                else if (verifReq.guild.guildRank.exact) {
                     if (verifReq.guild.guildRank.minRank !== resp.guildRank) {
                         result.fatalIssues.push({
                             key: "Not In Correct Guild",

--- a/src/private-api/PrivateApiDefinitions.ts
+++ b/src/private-api/PrivateApiDefinitions.ts
@@ -118,8 +118,8 @@ export namespace PrivateApiDefinitions {
         exp: number;
         rank: number;
         accountFame: number;
-        guild: string;
-        guildRank: string;
+        guild?: string;
+        guildRank?: string;
         firstSeen?: string;
         created?: string;
         lastSeen: string;

--- a/src/utilities/MiscUtilities.ts
+++ b/src/utilities/MiscUtilities.ts
@@ -107,7 +107,12 @@ export namespace MiscUtilities {
      * @param {string} desc The description (i.e. instructions) to post.
      * @return {Promise<ISectionInfo | null>} The section, if any. Null otherwise.
      */
-    export async function getSectionQuery(guildDb: IGuildInfo, member: GuildMember, channel: TextChannel, desc: string): Promise<[ISectionInfo, Message | null] | null> {
+    export async function getSectionQuery(
+        guildDb: IGuildInfo,
+        member: GuildMember, 
+        channel: TextChannel, 
+        desc: string
+    ): Promise<[ISectionInfo, Message | null] | null> {
         const allSections = MongoManager.getAllSections(guildDb);
         const selectOptions: MessageSelectOptionData[] = allSections
             .map(x => {
@@ -151,7 +156,9 @@ export namespace MiscUtilities {
 
         // Button = guaranteed to be a button.
         if (!result || !result.isSelectMenu()) {
-            askMsg.delete().catch();
+            if (result?.message) {
+                MessageUtilities.tryDelete(result.message as Message).then();
+            }
             return null;
         }
 
@@ -215,7 +222,6 @@ export namespace MiscUtilities {
 
         // Button = guaranteed to be a button.
         if (!result || !result.isSelectMenu()) {
-            message.delete().catch();
             return null;
         }
         return allSections.find(x => x.uniqueIdentifier === result.values[0])!;


### PR DESCRIPTION
This PR fixes a few bugs for verification found during the initial testing period, along with a few other bugs elsewhere.

## Fixes
- Possibly fixed a bug where the bot would change the nickname or add the role, and then somehow immediately undo that operation (this is most likely caused by a rate limiting issue on Discord's side).
- The bot will no longer ping moderators in any verification logging messages (e.g., you won't get a ping when you manually verify someone).
- Verification log messages are more consistent.
- Fixed a bug where members with the same username as their desired in-game name won't get a nickname change. 
    - What should happen is, if a member has the same username as the desired IGN, a dot will be appended to their name. 
    - What actually happens is that the bot doesn't change their nickname, resulting in the member's ability to change their username and thus their nickname,
- Fixed a bug where the bot throws an error during verification if the user isn't in a guild.
- Fixed a bug where a certain condition of closing a configuration message will throw an error.
- Fixed a bug where section verification (when the "No Requirements" option is explicitly set) doesn't give the section verified role.
    - What should happen is, when the user presses the "Verify Me" button, the bot immediately gives the section verified role.
    - What actually happens is that the bot gives the main verified role, and since the user already has the main verified role, nothing happens.