### PR TITLE
refactor(afk-check): require location before start

### DIFF
--- a/src/commands/config/ConfigDungeons.ts
+++ b/src/commands/config/ConfigDungeons.ts
@@ -912,7 +912,6 @@ export class ConfigDungeons extends BaseCommand {
                             }
                         });
                     }
-                    console.log("return:" + (dgnToOverrideInfo && ConfigDungeons.isDefaultOverride(cDungeon, dgnToOverrideInfo)));
                     if (!isCustomDungeon(cDungeon)
                         && dgnToOverrideInfo
                         && ConfigDungeons.isDefaultOverride(cDungeon, dgnToOverrideInfo)) {

--- a/src/commands/config/ConfigDungeons.ts
+++ b/src/commands/config/ConfigDungeons.ts
@@ -748,6 +748,8 @@ export class ConfigDungeons extends BaseCommand {
                     : false
             );
 
+            configLocationRequirement.setStyle(cDungeon.locationToProgress ? "SUCCESS" : "DANGER");
+
             const ptCostStr = (cDungeon.pointCost === 0
                 ? "Point System Not Used"
                 : cDungeon.pointCost).toString();
@@ -1310,11 +1312,6 @@ export class ConfigDungeons extends BaseCommand {
                     break;
                 }
                 case "require_loc": {
-                    const newStyle = !cDungeon.locationToProgress ? "SUCCESS" : "DANGER";
-                    configLocationRequirement.setStyle(newStyle);
-
-                    await botMsg.edit({ embeds: [embed], components: AdvancedCollector.getActionRowsFromComponents(buttons) });
-
                     cDungeon.locationToProgress = !cDungeon.locationToProgress;
                     break;
                 }

--- a/src/commands/config/ConfigDungeons.ts
+++ b/src/commands/config/ConfigDungeons.ts
@@ -170,6 +170,9 @@ export class ConfigDungeons extends BaseCommand {
         if (numEq !== 0)
             return false;
 
+        if (dgnOverride.locationToProgress !== origDungeon.locationToProgress)
+            return false;
+
         return dgnOverride.nitroEarlyLocationLimit === -1
             && dgnOverride.vcLimit === -1
             && dgnOverride.pointCost === 0
@@ -660,6 +663,10 @@ export class ConfigDungeons extends BaseCommand {
             .setLabel("Configure Modifiers")
             .setCustomId("config_modifiers")
             .setStyle("PRIMARY");
+        const configLocationRequirement = new MessageButton()
+            .setLabel("Require Location")
+            .setCustomId("require_loc")
+            .setStyle(cDungeon.locationToProgress ? "SUCCESS" : "DANGER");
 
         let dgnToOverrideInfo: IDungeonInfo | null = null;
 
@@ -725,6 +732,7 @@ export class ConfigDungeons extends BaseCommand {
             vcLimitButton,
             roleReqButton,
             configModifiers,
+            configLocationRequirement,
             saveButton,
             removeButton
         );
@@ -840,6 +848,10 @@ export class ConfigDungeons extends BaseCommand {
                 "Click on the `Role Requirements` button to add or remove any additional roles needed to run this"
                 + " particular dungeon. For example, for full-skip dungeons, you might require a Fullskip role. The"
                 + ` number of role(s) set is: \`${cDungeon.roleRequirement.length}\``
+            ).addField(
+                "Require Location",
+                "Click on the `Require Location` button to require a location before being able to progress an AFK-"
+                + "check to the closed stage. Green indicates that this value is required"
             );
 
             embed.addField(
@@ -1295,6 +1307,15 @@ export class ConfigDungeons extends BaseCommand {
                     }
 
                     cDungeon.allowedModifiers = res;
+                    break;
+                }
+                case "require_loc": {
+                    const newStyle = !cDungeon.locationToProgress ? "SUCCESS" : "DANGER";
+                    configLocationRequirement.setStyle(newStyle);
+
+                    await botMsg.edit({ embeds: [embed], components: AdvancedCollector.getActionRowsFromComponents(buttons) });
+
+                    cDungeon.locationToProgress = !cDungeon.locationToProgress;
                     break;
                 }
             }

--- a/src/commands/config/ConfigDungeons.ts
+++ b/src/commands/config/ConfigDungeons.ts
@@ -170,7 +170,7 @@ export class ConfigDungeons extends BaseCommand {
         if (numEq !== 0)
             return false;
 
-        if (dgnOverride.locationToProgress !== origDungeon.locationToProgress)
+        if (dgnOverride.locationToProgress || origDungeon.locationToProgress !== undefined)
             return false;
 
         return dgnOverride.nitroEarlyLocationLimit === -1
@@ -209,7 +209,8 @@ export class ConfigDungeons extends BaseCommand {
             vcLimit: -1,
             roleRequirement: [],
             logFor: null,
-            allowedModifiers: DEFAULT_MODIFIERS.map(x => x.modifierId)
+            allowedModifiers: DEFAULT_MODIFIERS.map(x => x.modifierId),
+            locationToProgress: dgn.locationToProgress
         } as ICustomDungeonInfo;
     }
 
@@ -420,7 +421,8 @@ export class ConfigDungeons extends BaseCommand {
                     vcLimit: -1,
                     pointCost: 0,
                     roleRequirement: [],
-                    allowedModifiers: DEFAULT_MODIFIERS.map(x => x.modifierId)
+                    allowedModifiers: DEFAULT_MODIFIERS.map(x => x.modifierId),
+                    locationToProgress: res.locationToProgress
                 } as IDungeonOverrideInfo));
                 return;
             }
@@ -626,7 +628,8 @@ export class ConfigDungeons extends BaseCommand {
             },
             roleRequirement: [],
             vcLimit: -1,
-            allowedModifiers: DEFAULT_MODIFIERS.map(x => x.modifierId)
+            allowedModifiers: DEFAULT_MODIFIERS.map(x => x.modifierId),
+            locationToProgress: false
         };
 
         const embed = new MessageEmbed();
@@ -909,7 +912,7 @@ export class ConfigDungeons extends BaseCommand {
                             }
                         });
                     }
-
+                    console.log("return:" + (dgnToOverrideInfo && ConfigDungeons.isDefaultOverride(cDungeon, dgnToOverrideInfo)));
                     if (!isCustomDungeon(cDungeon)
                         && dgnToOverrideInfo
                         && ConfigDungeons.isDefaultOverride(cDungeon, dgnToOverrideInfo)) {

--- a/src/constants/dungeons/DungeonData.ts
+++ b/src/constants/dungeons/DungeonData.ts
@@ -1764,6 +1764,7 @@ export const DUNGEON_DATA: readonly IDungeonInfo[] = [
             0x000000
         ],
         dungeonCategory: "Exaltation Dungeons",
-        isBuiltIn: true
+        isBuiltIn: true,
+        locationToProgress: true
     }
 ];

--- a/src/definitions/DungeonRaidInterfaces.ts
+++ b/src/definitions/DungeonRaidInterfaces.ts
@@ -98,6 +98,13 @@ export interface IDungeonOverrideInfo {
      * @type {string[]}
      */
     allowedModifiers: string[];
+    
+    /**
+     * Whether or not location is required to progress the afk check.
+     * 
+     * @type {boolean}
+     */
+    locationToProgress?: boolean;
 }
 
 /**
@@ -234,6 +241,13 @@ export interface IDungeonInfo {
      * @type {boolean}
      */
     isBuiltIn: boolean;
+
+    /**
+     * Whether or not a set location is required to progress the afk check.
+     * 
+     * @type {boolean}
+     */
+    locationToProgress?: boolean;
 }
 
 /**

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -401,7 +401,10 @@ export class RaidInstance {
                     })
                     .filter((x) => x) as IDungeonModifier[];
             }
+
+            // If the dungeon has an override
             if (dgnOverride && dgnOverride.locationToProgress) locationToProgress = true;
+            // In the case that there is no override, fallback to the information from constants/dungeons/DungeonData
             else if (!dgnOverride && dungeon.locationToProgress) locationToProgress = true;
         } else {
             // If this is not a base or derived dungeon (i.e. it's a custom dungeon), then it must specify the nitro

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -409,6 +409,7 @@ export class RaidInstance {
             }
 
             if (dgnOverride && dgnOverride.locationToProgress) locationToProgress = true;
+            else if (!dgnOverride && dungeon.locationToProgress) locationToProgress = true;
         } else {
             // If this is not a base or derived dungeon (i.e. it's a custom dungeon), then it must specify the nitro
             // limit.

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -233,6 +233,8 @@ export class RaidInstance {
     private readonly _leaderName: string;
     // The cost, in points, for early location.
     private readonly _earlyLocPointCost: number;
+    // Override info concerning whether you can start without location
+    private readonly _locationToProgress: boolean;
 
     // The members that are joining this raid.
     private _membersThatJoined: GuildMember[] = [];
@@ -383,6 +385,8 @@ export class RaidInstance {
         let vcLimit: number = -2;
         // And this is the point cost.
         let costForEarlyLoc: number = 0;
+        // Override info concerning whether you can start without location
+        let locationToProgress: boolean = false;
         // Process dungeon based on whether it is custom or not.
         if (dungeon.isBuiltIn) {
             const dgnOverride = guildDoc.properties.dungeonOverride.find((x) => x.codeName === dungeon.codeName);
@@ -403,6 +407,8 @@ export class RaidInstance {
                     })
                     .filter((x) => x) as IDungeonModifier[];
             }
+
+            if (dgnOverride && dgnOverride.locationToProgress) locationToProgress = true;
         } else {
             // If this is not a base or derived dungeon (i.e. it's a custom dungeon), then it must specify the nitro
             // limit.
@@ -418,6 +424,7 @@ export class RaidInstance {
         }
 
         this._earlyLocPointCost = costForEarlyLoc;
+        this._locationToProgress = locationToProgress;
 
         if (vcLimit === -2) {
             if (section.otherMajorConfig.afkCheckProperties.vcLimit !== -1)
@@ -2763,10 +2770,10 @@ export class RaidInstance {
                 await i.deferUpdate();
                 if (i.customId === RaidInstance.START_AFK_CHECK_ID) {
                     LOGGER.info(`${this._instanceInfo} Leader chose to start AFK Check`);
-                    if (this._location)
-                        this.startAfkCheck().then();
-                    else
+                    if (this._locationToProgress && !this._location)
                         i.followUp({ content: "Please set a location prior to progressing the raid.", ephemeral: true });
+                    else
+                        this.startAfkCheck().then();
                     return;
                 }
 

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -2763,7 +2763,10 @@ export class RaidInstance {
                 await i.deferUpdate();
                 if (i.customId === RaidInstance.START_AFK_CHECK_ID) {
                     LOGGER.info(`${this._instanceInfo} Leader chose to start AFK Check`);
-                    this.startAfkCheck().then();
+                    if (this._location)
+                        this.startAfkCheck().then();
+                    else
+                        i.followUp({ content: "Please set a location prior to progressing the raid.", ephemeral: true });
                     return;
                 }
 


### PR DESCRIPTION
~~location is now required before starting the raid~~
added config option to require location per dungeon, oryx 3 defaults to true (since it's the only one that cannot ever proceed in a bazaar)

closes #220 