### PR TITLE
feat(verif): forced manual verification added

### DIFF
--- a/src/commands/config/ConfigVerification.ts
+++ b/src/commands/config/ConfigVerification.ts
@@ -33,6 +33,7 @@ import { ButtonConstants } from "../../constants/ButtonConstants";
 import { MessageUtilities } from "../../utilities/MessageUtilities";
 import { VerifyManager } from "../../managers/VerifyManager";
 import SHORT_STAT_TO_LONG = VerifyManager.SHORT_STAT_TO_LONG;
+import { GlobalFgrUtilities } from "../../utilities/fetch-get-request/GlobalFgrUtilities";
 
 export class ConfigVerification extends BaseCommand {
     public static GUILD_RANKS: string[] = [
@@ -157,6 +158,10 @@ export class ConfigVerification extends BaseCommand {
             verificationSuccessMessage: section.otherMajorConfig.verificationProperties.verificationSuccessMessage,
             additionalVerificationInfo: section.otherMajorConfig.verificationProperties.additionalVerificationInfo
         };
+
+        if (!verifConfig.useDefault && GlobalFgrUtilities.getCachedChannel(ctx.guildDoc!.channels.storageChannelId)) {
+            verifConfig.useDefault = true;
+        }
 
         while (true) {
             const buttons: MessageButton[] = [];

--- a/src/commands/config/ConfigVerification.ts
+++ b/src/commands/config/ConfigVerification.ts
@@ -151,9 +151,7 @@ export class ConfigVerification extends BaseCommand {
         const verifConfig: IVerificationProperties = {
             useDefault: section.otherMajorConfig.verificationProperties.useDefault ?? true,
             instructionsManualVerification: section.otherMajorConfig.verificationProperties.instructionsManualVerification
-                ?? "Please send a screenshot of you in-game **in your vault** saying your"
-                + " Discord tag. Your Discord tag must be clearly visible in the chat bubble"
-                + " and in the chat box. Additionally, your in-game name must be clearly visible.",
+                ?? VerifyManager.DEFAULT_MANUAL_INSTRUCTIONS,
             checkRequirements: section.otherMajorConfig.verificationProperties.checkRequirements,
             verifReq: { ...section.otherMajorConfig.verificationProperties.verifReq },
             verificationSuccessMessage: section.otherMajorConfig.verificationProperties.verificationSuccessMessage,

--- a/src/commands/config/ConfigVerification.ts
+++ b/src/commands/config/ConfigVerification.ts
@@ -159,7 +159,8 @@ export class ConfigVerification extends BaseCommand {
             additionalVerificationInfo: section.otherMajorConfig.verificationProperties.additionalVerificationInfo
         };
 
-        if (!verifConfig.useDefault && GlobalFgrUtilities.getCachedChannel(ctx.guildDoc!.channels.storageChannelId)) {
+        // The storage channel must exist since we need it to store manual verification screenshots.
+        if (!verifConfig.useDefault && !GlobalFgrUtilities.getCachedChannel(ctx.guildDoc!.channels.storageChannelId)) {
             verifConfig.useDefault = true;
         }
 
@@ -170,7 +171,9 @@ export class ConfigVerification extends BaseCommand {
                     new MessageButton()
                         .setStyle("PRIMARY")
                         .setLabel("Force Manual Verify")
-                        .setCustomId("toggle_type"),
+                        .setCustomId("toggle_type")
+                        // Once again, the storage channel must exist.
+                        .setDisabled(!GlobalFgrUtilities.getCachedChannel(ctx.guildDoc!.channels.storageChannelId)),
                     new MessageButton()
                         .setStyle("PRIMARY")
                         .setCustomId("check_reqs")
@@ -226,7 +229,8 @@ export class ConfigVerification extends BaseCommand {
 
             if (verifConfig.useDefault) {
                 desc.append("- Press the **Force Manual Verify** button if you want to require everyone to go through")
-                    .append(" the manual verification process.")
+                    .append(" the manual verification process. **Note** that this requires the storage channel to be")
+                    .append(" configured for the server.")
                     .appendLine()
                     .append("- Press the **Check Requirements** button if you want to enable or disable the checking")
                     .append(" of requirements for this section.").appendLine()
@@ -514,11 +518,11 @@ export class ConfigVerification extends BaseCommand {
                                 .append("In order to get access to the section, ");
                         }
 
-                        desc.append("you will need to verify your identity with the bot and upload a screenshot that")
-                            .append(" meets the following screenshot requirements:")
-                            .append(StringUtil.codifyString(
-                                verifConfig.instructionsManualVerification
-                            ));
+                        descSb.append("you will need to verify your identity with the bot and upload a screenshot that")
+                            .append(" meets the following screenshot requirements:").appendLine()
+                            .append(
+                                verifConfig.instructionsManualVerification.split("\n").map(x => "> " + x).join("\n")
+                            );
                     }
                     
                     descSb.appendLine()

--- a/src/commands/config/ConfigVerification.ts
+++ b/src/commands/config/ConfigVerification.ts
@@ -152,7 +152,8 @@ export class ConfigVerification extends BaseCommand {
             useDefault: section.otherMajorConfig.verificationProperties.useDefault ?? true,
             instructionsManualVerification: section.otherMajorConfig.verificationProperties.instructionsManualVerification
                 ?? "Please send a screenshot of you in-game **in your vault** saying your"
-                + " Discord tag. This must clearly be visible as a chat bubble and in the chat box.",
+                + " Discord tag. Your Discord tag must be clearly visible in the chat bubble"
+                + " and in the chat box. Additionally, your in-game name must be clearly visible.",
             checkRequirements: section.otherMajorConfig.verificationProperties.checkRequirements,
             verifReq: { ...section.otherMajorConfig.verificationProperties.verifReq },
             verificationSuccessMessage: section.otherMajorConfig.verificationProperties.verificationSuccessMessage,
@@ -526,6 +527,7 @@ export class ConfigVerification extends BaseCommand {
                     }
                     
                     descSb.appendLine()
+                        .appendLine()
                         .append("If you meet the requirements posted above, please press the **Verify Me** button.")
                         .append(" __Make sure anyone can direct message you.__");
                 

--- a/src/commands/config/ConfigVerification.ts
+++ b/src/commands/config/ConfigVerification.ts
@@ -160,8 +160,11 @@ export class ConfigVerification extends BaseCommand {
             additionalVerificationInfo: section.otherMajorConfig.verificationProperties.additionalVerificationInfo
         };
 
-        // The storage channel must exist since we need it to store manual verification screenshots.
-        if (!verifConfig.useDefault && !GlobalFgrUtilities.getCachedChannel(ctx.guildDoc!.channels.storageChannelId)) {
+        // The storage + manual verification channel must exist since we need it to store manual verification screenshots
+        // and process manual verification requests.
+        if (!verifConfig.useDefault 
+            && (!GlobalFgrUtilities.getCachedChannel(ctx.guildDoc!.channels.storageChannelId)
+                || !GlobalFgrUtilities.getCachedChannel(ctx.guildDoc!.channels.verification.manualVerificationChannelId))) {
             verifConfig.useDefault = true;
         }
 
@@ -220,6 +223,7 @@ export class ConfigVerification extends BaseCommand {
                     .setCustomId("send")
                     .setDisabled(
                         !GuildFgrUtilities.hasCachedChannel(ctx.guild!, section.channels.verification.verificationChannelId)
+                        || !GlobalFgrUtilities.getCachedChannel(ctx.guildDoc!.channels.verification.manualVerificationChannelId)
                     )
             );
 
@@ -230,8 +234,8 @@ export class ConfigVerification extends BaseCommand {
 
             if (verifConfig.useDefault) {
                 desc.append("- Press the **Force Manual Verify** button if you want to require everyone to go through")
-                    .append(" the manual verification process. **Note** that this requires the storage channel to be")
-                    .append(" configured for the server.")
+                    .append(" the manual verification process. **Note** that this requires the storage channel and")
+                    .append(" manual verification channels to be configured for the server.")
                     .appendLine()
                     .append("- Press the **Check Requirements** button if you want to enable or disable the checking")
                     .append(" of requirements for this section.").appendLine()

--- a/src/commands/config/ConfigVerification.ts
+++ b/src/commands/config/ConfigVerification.ts
@@ -177,7 +177,9 @@ export class ConfigVerification extends BaseCommand {
                         .setLabel("Force Manual Verify")
                         .setCustomId("toggle_type")
                         // Once again, the storage channel must exist.
-                        .setDisabled(!GlobalFgrUtilities.getCachedChannel(ctx.guildDoc!.channels.storageChannelId)),
+                        .setDisabled(
+                            !GlobalFgrUtilities.getCachedChannel(ctx.guildDoc!.channels.storageChannelId)
+                            || !GlobalFgrUtilities.getCachedChannel(ctx.guildDoc!.channels.verification.manualVerificationChannelId)),
                     new MessageButton()
                         .setStyle("PRIMARY")
                         .setCustomId("check_reqs")
@@ -223,7 +225,6 @@ export class ConfigVerification extends BaseCommand {
                     .setCustomId("send")
                     .setDisabled(
                         !GuildFgrUtilities.hasCachedChannel(ctx.guild!, section.channels.verification.verificationChannelId)
-                        || !GlobalFgrUtilities.getCachedChannel(ctx.guildDoc!.channels.verification.manualVerificationChannelId)
                     )
             );
 

--- a/src/commands/staff/CheckManualVerifyApp.ts
+++ b/src/commands/staff/CheckManualVerifyApp.ts
@@ -1,5 +1,6 @@
 import { MessageButton } from "discord.js";
 import { EmojiConstants } from "../../constants/EmojiConstants";
+import { MongoManager } from "../../managers/MongoManager";
 import { VerifyManager } from "../../managers/VerifyManager";
 import { AdvancedCollector } from "../../utilities/collectors/AdvancedCollector";
 import { GuildFgrUtilities } from "../../utilities/fetch-get-request/GuildFgrUtilities";
@@ -52,9 +53,13 @@ export class CheckManualVerifyApp extends BaseCommand {
         let page = 0;
         for await (const m of ctx.guildDoc!.manualVerificationEntries) {
             ++page;
-            const section = ctx.guildDoc!.guildSections.find(x => x.uniqueIdentifier === m.sectionId);
+            let section = ctx.guildDoc!.guildSections.find(x => x.uniqueIdentifier === m.sectionId);
             if (!section) {
-                continue;
+                if (m.sectionId !== "MAIN") {
+                    continue;
+                }
+                
+                section = MongoManager.getMainSection(ctx.guildDoc!);
             }
 
             const member = await GuildFgrUtilities.fetchGuildMember(ctx.guild!, m.userId);

--- a/src/commands/staff/CheckManualVerifyApp.ts
+++ b/src/commands/staff/CheckManualVerifyApp.ts
@@ -85,7 +85,10 @@ export class CheckManualVerifyApp extends BaseCommand {
                         .toString()
                 )
                 .setFooter({ text: `Page ${page}/${ctx.guildDoc!.manualVerificationEntries.length}` });
-
+            if (m.url) {
+                embed.setImage(m.url);
+            }
+            
             const baseId = StringUtil.generateRandomString(15);
             const accId = baseId + "accept";
             const rejId = baseId + "reject";

--- a/src/commands/staff/EditName.ts
+++ b/src/commands/staff/EditName.ts
@@ -288,7 +288,7 @@ export class EditName extends BaseCommand {
         const [, newNameInDb] = names.get(newIgn.toLowerCase()) ?? [undefined, false];
 
         const oldNameLowercase = res.values[0].toLowerCase();
-        const [origName, isInDb, wasNickname] = names.get(oldNameLowercase)!;
+        const [, isInDb, wasNickname] = names.get(oldNameLowercase)!;
         let updatedDb = false;
         // If the original name is in the database AND the new name is not the same as the old name AND the new name
         // is not already in the database
@@ -310,13 +310,6 @@ export class EditName extends BaseCommand {
             await MongoManager.getIdNameCollection().updateOne({ currentDiscordId: doc[0].currentDiscordId }, {
                 $set: {
                     rotmgNames: allNames
-                },
-                $push: {
-                    pastRealmNames: {
-                        ign: oldNameLowercase,
-                        lowercaseIgn: origName,
-                        toDate: Date.now()
-                    }
                 }
             });
             updatedDb = true;

--- a/src/commands/staff/Find.ts
+++ b/src/commands/staff/Find.ts
@@ -8,7 +8,6 @@ import { StringBuilder } from "../../utilities/StringBuilder";
 import { StringUtil } from "../../utilities/StringUtilities";
 import { Bot } from "../../Bot";
 import { TimeUtilities } from "../../utilities/TimeUtilities";
-import { ArrayUtilities } from "../../utilities/ArrayUtilities";
 import { EmojiConstants } from "../../constants/EmojiConstants";
 import { AdvancedCollector } from "../../utilities/collectors/AdvancedCollector";
 import { GlobalFgrUtilities } from "../../utilities/fetch-get-request/GlobalFgrUtilities";
@@ -171,31 +170,11 @@ export class Find extends BaseCommand {
             successEmbed.addField(
                 "ID Information",
                 new StringBuilder()
-                    .append(`Past Name(s): \`${id.pastRealmNames.length}\``).appendLine()
-                    .append(`Past ID(s): \`${id.pastDiscordIds.length}\``).appendLine()
                     .append(`Connected ID: \`${id.currentDiscordId}\``).appendLine()
                     .append(`Connected Name(s): ${StringUtil.codifyString(
                         `[${id.rotmgNames.map(x => x.ign).join(", ")}]`
                     )}`).toString()
             );
-
-            const pNamesDisplay = ArrayUtilities.breakArrayIntoSubsets(
-                id.pastRealmNames.map(x => `- \`${x.ign}\` (To ${getDateTime(x.toDate)} GMT)`),
-                5
-            );
-
-            const pIdDisplay = ArrayUtilities.breakArrayIntoSubsets(
-                id.pastDiscordIds.map(x => `- \`${x.oldId}\` (To ${getDateTime(x.toDate)} GMT)`),
-                5
-            );
-
-            for (const pastName of pNamesDisplay) {
-                successEmbed.addField("Past Name(s)", pastName.join("\n"), true);
-            }
-
-            for (const pastId of pIdDisplay) {
-                successEmbed.addField("Past ID(s)", pastId.join("\n"), true);
-            }
         }
 
         successEmbed.addField(

--- a/src/commands/staff/ManualVerifyMain.ts
+++ b/src/commands/staff/ManualVerifyMain.ts
@@ -2,7 +2,6 @@ import { ArgumentType, BaseCommand, ICommandContext, ICommandInfo } from "../Bas
 import { UserManager } from "../../managers/UserManager";
 import { GuildFgrUtilities } from "../../utilities/fetch-get-request/GuildFgrUtilities";
 import { MongoManager } from "../../managers/MongoManager";
-import { IRealmIgn } from "../../definitions";
 import { MessageSelectMenu, TextChannel } from "discord.js";
 import { GlobalFgrUtilities } from "../../utilities/fetch-get-request/GlobalFgrUtilities";
 import { MessageUtilities } from "../../utilities/MessageUtilities";
@@ -109,7 +108,7 @@ export class ManualVerifyMain extends BaseCommand {
                 return -1;
             }
 
-            const ignToUse = await new Promise<IRealmIgn | null>(async r => {
+            const ignToUse = await new Promise<string | null>(async r => {
                 if (docs.length === 0 || docs[0].rotmgNames.length === 0) {
                     await ctx.interaction.editReply({
                         content: "No IGNs could be found for this person. Please provide an IGN by re-running this"
@@ -119,7 +118,7 @@ export class ManualVerifyMain extends BaseCommand {
                 }
 
                 if (docs[0].rotmgNames.length === 1) {
-                    return r(docs[0].rotmgNames[0]);
+                    return r(docs[0].rotmgNames[0].ign);
                 }
 
                 const selectMenu = new MessageSelectMenu()
@@ -158,19 +157,20 @@ export class ManualVerifyMain extends BaseCommand {
                 });
 
                 if (!selected) {
-                    return null;
+                    return r(null);
                 }
 
-                return !selected.isSelectMenu()
-                    ? null
-                    : selected.values[0];
+                return r(!selected.isSelectMenu() ? null : selected.values[0]);
             });
 
             if (!ignToUse) {
+                await ctx.interaction.editReply({
+                    content: "The process has either timed out or has been canceled."
+                });
                 return 0;
             }
 
-            ignToVerifyWith = ignToUse.ign;
+            ignToVerifyWith = ignToUse;
             useAlreadyVerifiedIgn = true;
         }
 

--- a/src/commands/staff/RemoveName.ts
+++ b/src/commands/staff/RemoveName.ts
@@ -160,13 +160,6 @@ export class RemoveName extends BaseCommand {
             await MongoManager.getIdNameCollection().updateOne({ currentDiscordId: member.id }, {
                 $set: {
                     rotmgNames: namesInDb
-                },
-                $push: {
-                    pastRealmNames: {
-                        ign: lowerCaseName,
-                        lowercaseIgn: origName,
-                        toDate: Date.now()
-                    }
                 }
             });
             updatedDb = true;

--- a/src/definitions/MongoDocumentInterfaces.ts
+++ b/src/definitions/MongoDocumentInterfaces.ts
@@ -563,37 +563,6 @@ export interface IIdNameInfo {
      * @type {IRealmIgn[]}
      */
     rotmgNames: IRealmIgn[];
-
-    /**
-     * Any past Discord IDs associated with the linked RotMG name(s).
-     *
-     * Essentially, any IDs taken out of `currentDiscordId`, for any reason, should be put right here.
-     *
-     * @type {({oldId: string;} & IPastEntry)[]}
-     */
-    pastDiscordIds: ({ oldId: string; } & IPastEntry)[];
-
-    /**
-     * Any past RotMG names associated with the linked IDs. This should primarily contain:
-     * - Names from name history (if the person changed his/her RotMG name).
-     * - Other names (in case the person got banned from said account or something and wants it removed).
-     *
-     * In any case, any names taken out of `rotmgNames`, for any reason, should be put right here.
-     *
-     * @type {(IRealmIgn & IPastEntry)[]}
-     */
-    pastRealmNames: (IRealmIgn & IPastEntry)[];
-}
-
-/**
- * An interface that represents a past entry. This only contains a date where the original entry was removed, and
- * should be used in conjunction with the old entry.
- */
-interface IPastEntry {
-    /**
-     * The date which the entry was removed.
-     */
-    toDate: number;
 }
 
 /**

--- a/src/definitions/VerificationInterfaces.ts
+++ b/src/definitions/VerificationInterfaces.ts
@@ -258,6 +258,13 @@ export interface IManualVerificationEntry {
      * @type {string}
      */
     sectionId: string;
+
+    /**
+     * The URL to an image, if any.
+     * 
+     * @type {string}
+     */
+    url?: string;
 }
 
 /**

--- a/src/definitions/VerificationInterfaces.ts
+++ b/src/definitions/VerificationInterfaces.ts
@@ -24,6 +24,21 @@ export interface IVerificationChannels {
  */
 export interface IVerificationProperties {
     /**
+     * Whether to use the default verification style (i.e., if this is `true`, then 
+     * verification will be done mostly automatically via RealmEye verification.)
+     * 
+     * @type {boolean}
+     */
+    useDefault: boolean; 
+
+    /**
+     * Instructions, to be asked to the user, for the manual verification process.
+     * 
+     * @type {string}
+     */
+    instructionsManualVerification: string;
+
+    /**
      * Any message to show on the verification embed.
      *
      * @type {string}

--- a/src/events/InteractionEvent.ts
+++ b/src/events/InteractionEvent.ts
@@ -1,4 +1,4 @@
-import { CommandInteraction, Interaction, Message } from "discord.js";
+import { CommandInteraction, Interaction } from "discord.js";
 import { Bot } from "../Bot";
 import { GuildFgrUtilities } from "../utilities/fetch-get-request/GuildFgrUtilities";
 import { MongoManager } from "../managers/MongoManager";
@@ -215,7 +215,9 @@ export async function onInteractionEvent(interaction: Interaction): Promise<void
         .find(x => x.manualVerifyMsgId === message.id && x.manualVerifyChannelId === channel.id);
 
     
-    if (manualVerifyChannels) {
+    if (manualVerifyChannels 
+        && message.embeds.length > 0 
+        && message.embeds[0].footer?.text === "Manual Verification Request") {
         interaction.deferUpdate().catch(LOGGER.error);
         VerifyManager.acknowledgeManualVerif(manualVerifyChannels, resolvedMember, interaction.customId, message)
             .then();
@@ -270,19 +272,18 @@ export async function onInteractionEvent(interaction: Interaction): Promise<void
     // ================================================================================================ //
 
     // Check modmail
-    if (channel.id === guildDoc.channels.modmailChannelId) {
+    if (channel.id === guildDoc.channels.modmailChannelId
+        && message.embeds.length > 0
+        && message.embeds[0].title?.startsWith("Modmail")) {
         interaction.deferUpdate().catch(LOGGER.error);
-        if (!(interaction.message instanceof Message) || interaction.message.embeds.length === 0) {
-            return;
-        }
 
         switch (interaction.customId) {
             case ButtonConstants.OPEN_THREAD_ID: {
-                await ModmailManager.openModmailThread(guildDoc, interaction.message, resolvedMember);
+                await ModmailManager.openModmailThread(guildDoc, message, resolvedMember);
                 return;
             }
             case ButtonConstants.REMOVE_ID: {
-                await ModmailManager.closeModmailThread(interaction.message, guildDoc);
+                await ModmailManager.closeModmailThread(message, guildDoc);
                 return;
             }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import { MAPPED_AFK_CHECK_REACTIONS } from "./constants/dungeons/MappedAfkCheckR
         console.error(`[!] ${mapKey} not valid`);
     }
 
-    const content = fs.readFileSync(path.join(__dirname, "..", "config.test1.json"));
+    const content = fs.readFileSync(path.join(__dirname, "..", "config.production.json"));
     const config: IConfiguration = JSON.parse(content.toString());
     const bot = new Bot(config);
     bot.startAllEvents();

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import { MAPPED_AFK_CHECK_REACTIONS } from "./constants/dungeons/MappedAfkCheckR
         console.error(`[!] ${mapKey} not valid`);
     }
 
-    const content = fs.readFileSync(path.join(__dirname, "..", "config.production.json"));
+    const content = fs.readFileSync(path.join(__dirname, "..", "config.test1.json"));
     const config: IConfiguration = JSON.parse(content.toString());
     const bot = new Bot(config);
     bot.startAllEvents();

--- a/src/managers/MongoManager.ts
+++ b/src/managers/MongoManager.ts
@@ -413,7 +413,8 @@ export namespace MongoManager {
             verificationProperties: {
                 useDefault: true,
                 instructionsManualVerification: "Please send a screenshot of you in-game **in your vault** saying your"
-                    + " Discord tag. This must clearly be visible as a chat bubble and in the chat box.",
+                    + " Discord tag. Your Discord tag must be clearly visible in the chat bubble"
+                    + " and in the chat box. Additionally, your in-game name must be clearly visible.",
                 checkRequirements: true,
                 additionalVerificationInfo: "",
                 verificationSuccessMessage: "",

--- a/src/managers/MongoManager.ts
+++ b/src/managers/MongoManager.ts
@@ -19,6 +19,7 @@ import { GlobalFgrUtilities } from "../utilities/fetch-get-request/GlobalFgrUtil
 import { DefinedRole } from "../definitions/Types";
 import { StringUtil } from "../utilities/StringUtilities";
 import { PermsConstants } from "../constants/PermsConstants";
+import { VerifyManager } from "./VerifyManager";
 
 export namespace MongoManager {
     export const CachedGuildCollection: DCollection<string, IGuildInfo> = new DCollection<string, IGuildInfo>();
@@ -400,9 +401,7 @@ export namespace MongoManager {
         return {
             verificationProperties: {
                 useDefault: true,
-                instructionsManualVerification: "Please send a screenshot of you in-game **in your vault** saying your"
-                    + " Discord tag. Your Discord tag must be clearly visible in the chat bubble"
-                    + " and in the chat box. Additionally, your in-game name must be clearly visible.",
+                instructionsManualVerification: VerifyManager.DEFAULT_MANUAL_INSTRUCTIONS,
                 checkRequirements: true,
                 additionalVerificationInfo: "",
                 verificationSuccessMessage: "",

--- a/src/managers/MongoManager.ts
+++ b/src/managers/MongoManager.ts
@@ -257,12 +257,6 @@ export namespace MongoManager {
             }, {
                 $set: {
                     currentDiscordId: member.id
-                },
-                $push: {
-                    pastDiscordIds: {
-                        oldId: oldDiscordId,
-                        toDate: Date.now()
-                    }
                 }
             }, { returnDocument: "after" });
 
@@ -290,12 +284,6 @@ export namespace MongoManager {
                     ign: name.ign
                 });
             }
-
-            if (entry.currentDiscordId !== member.id)
-                newObj.pastDiscordIds.push({ oldId: entry.currentDiscordId, toDate: Date.now() });
-
-            newObj.pastRealmNames.push(...entry.pastRealmNames);
-            newObj.pastDiscordIds.push(...entry.pastDiscordIds);
         }
 
         await getIdNameCollection().deleteMany({
@@ -583,9 +571,7 @@ export namespace MongoManager {
     export function getDefaultIdNameObj(userId: string, ign?: string): IIdNameInfo {
         return {
             rotmgNames: ign ? [{ lowercaseIgn: ign.toLowerCase(), ign: ign }] : [],
-            currentDiscordId: userId,
-            pastDiscordIds: [],
-            pastRealmNames: []
+            currentDiscordId: userId
         };
     }
 

--- a/src/managers/MongoManager.ts
+++ b/src/managers/MongoManager.ts
@@ -411,6 +411,9 @@ export namespace MongoManager {
 
         return {
             verificationProperties: {
+                useDefault: true,
+                instructionsManualVerification: "Please send a screenshot of you in-game **in your vault** saying your"
+                    + " Discord tag. This must clearly be visible as a chat bubble and in the chat box.",
                 checkRequirements: true,
                 additionalVerificationInfo: "",
                 verificationSuccessMessage: "",

--- a/src/managers/VerifyManager.ts
+++ b/src/managers/VerifyManager.ts
@@ -1126,9 +1126,6 @@ export namespace VerifyManager {
                 return;
             }
 
-            setTimeout(() => {
-                m.delete();
-            }, 5 * 1000);
             return at.attachment;
         });
 
@@ -1192,6 +1189,11 @@ export namespace VerifyManager {
             .append(" that is used to identify the player (e.g., in-game name, Discord tag) matches the information")
             .append(" that is shown above.");
 
+        if (instance.section.isMainSection) {
+            descSb.append(" Note that the IGN shown above (exactly as typed) will be registered into the bot's")
+                .append(" database. Thus, it's important that the IGN shown above is typed exactly as shown")
+                .append(" in-game.");
+        }
             
         const embed = MessageUtilities.generateBlankEmbed(instance.member, "YELLOW")
             .setTitle(`[${instance.section.sectionName}] Automated Manual Verification`)

--- a/src/managers/VerifyManager.ts
+++ b/src/managers/VerifyManager.ts
@@ -448,7 +448,7 @@ export namespace VerifyManager {
             nameToVerify = selected;
         }
 
-        if (!instance.section.otherMajorConfig.verificationProperties.useDefault) {
+        if (!(instance.section.otherMajorConfig.verificationProperties.useDefault ?? true)) {
             forcedManualVerify(msg, dmChan, instance, nameToVerify).then();
             return;
         }
@@ -842,9 +842,10 @@ export namespace VerifyManager {
      * @private
      */
     async function verifySection(interaction: MessageComponentInteraction, instance: IVerificationInstance): Promise<void> {
+        const useDefault = instance.section.otherMajorConfig.verificationProperties.useDefault ?? true;
         if (!instance.section.otherMajorConfig.verificationProperties.checkRequirements
             // This conditional is required so users don't just bypass manual verification if explicitly asked for
-            && instance.section.otherMajorConfig.verificationProperties.useDefault) {
+            && useDefault) {
             await GlobalFgrUtilities.tryExecuteAsync(async () => {
                 await instance.member.roles.add(
                     instance.section.roles.verifiedRoleId,
@@ -895,7 +896,7 @@ export namespace VerifyManager {
             nameToUse = names[0];
         }
 
-        if (!instance.section.otherMajorConfig.verificationProperties.useDefault) {
+        if (!useDefault) {
             // First, we need to see if the person can be DMed.
             const msgDmResp = await dmMember(instance.member);
             if (!msgDmResp) {
@@ -1248,8 +1249,8 @@ export namespace VerifyManager {
         });
 
         const displaySec = instance.section.isMainSection
-            ? `the section, \`${instance.section.sectionName}\` (${guild.name})`
-            : `the guild, \`${guild.name}\``;
+            ? `the guild, \`${guild.name}\``
+            : `the section, \`${instance.section.sectionName}\` (${guild.name})`;
         await GlobalFgrUtilities.sendMsg(dmChan, {
             content: `You have successfully sent a manual verification in ${displaySec}. No further action is`
                 + " required from you. Please do not message server staff about the status of your manual"

--- a/src/managers/VerifyManager.ts
+++ b/src/managers/VerifyManager.ts
@@ -32,6 +32,10 @@ import { QuotaManager } from "./QuotaManager";
 import * as Stream from "stream";
 
 export namespace VerifyManager {
+    export const DEFAULT_MANUAL_INSTRUCTIONS: string = "Please send a screenshot of you in-game **in your "
+        + " vault** saying your Discord tag. Your Discord tag must be clearly visible in the chat bubble"
+        + " and in the chat box. Additionally, your in-game name must be clearly visible.";
+
     export const NUMBER_OF_STATS: number = 8;
 
     export const SHORT_STAT_TO_LONG: { [s: string]: [string, string] } = {
@@ -1064,7 +1068,14 @@ export namespace VerifyManager {
             baseEmbed.setTitle(`${guild.name} ⇨ **${instance.section.sectionName}**: Section Verification`);
         }
 
-        const instructions = instance.section.otherMajorConfig.verificationProperties.instructionsManualVerification;
+        let instructions = instance.section.otherMajorConfig.verificationProperties.instructionsManualVerification as string | undefined;
+        if (typeof instructions === "undefined") {
+            instructions = VerifyManager.DEFAULT_MANUAL_INSTRUCTIONS;
+        }
+        else if (instructions.length === 0) {
+            instructions = "No instructions configured. Please ask staff for more information.";
+        }
+
         const r = await MessageUtilities.tryEdit(msg, {
             content: null,
             embeds: [

--- a/src/managers/VerifyManager.ts
+++ b/src/managers/VerifyManager.ts
@@ -1306,6 +1306,7 @@ export namespace VerifyManager {
                     }
                 });
 
+                await MessageUtilities.tryDelete(manualVerifMsg);
                 return;
             }
 
@@ -1315,6 +1316,7 @@ export namespace VerifyManager {
 
         // No verified role = no point in manually verifying that person.
         if (!GuildFgrUtilities.hasCachedRole(mod.guild, section.roles.verifiedRoleId)) {
+            await MessageUtilities.tryDelete(manualVerifMsg);
             return;
         }
 
@@ -1330,9 +1332,7 @@ export namespace VerifyManager {
         );
         
         // Now, let's respond based on the response ID.
-        const promises: (Promise<unknown> | undefined)[] = [
-            MessageUtilities.tryDelete(manualVerifMsg)
-        ];
+        const promises: (Promise<unknown> | undefined)[] = [];
 
         switch (responseId) {
             case (MANUAL_VERIFY_ACCEPT_ID): {
@@ -1391,6 +1391,18 @@ export namespace VerifyManager {
                     );
                 }
 
+                if (manualVerifMsg) {
+                    const oldEmbed = manualVerifMsg.embeds[0];
+                    await MessageUtilities.tryEdit(manualVerifMsg, {
+                        embeds: [
+                            oldEmbed
+                                .setTitle(`${EmojiConstants.GREEN_CHECK_EMOJI} ${oldEmbed.title}`)
+                                .setColor("DARK_GREEN")
+                                .addField("Status", `Accepted by ${mod.toString()} (${mod.user.tag}).`)
+                        ]
+                    }); 
+                }
+
                 break;
             }
             case (MANUAL_VERIFY_DENY_ID): {
@@ -1419,6 +1431,18 @@ export namespace VerifyManager {
                         allowedMentions: { roles: [], users: [] }
                     })
                 );
+
+                if (manualVerifMsg) {
+                    const oldEmbed = manualVerifMsg.embeds[0];
+                    await MessageUtilities.tryEdit(manualVerifMsg, {
+                        embeds: [
+                            oldEmbed
+                                .setTitle(`${EmojiConstants.X_EMOJI} ${oldEmbed.title}`)
+                                .setColor("DARK_RED")
+                                .addField("Status", `Rejected by ${mod.toString()} (${mod.user.tag}).`)
+                        ]
+                    }); 
+                }
 
                 break;
             }

--- a/src/managers/VerifyManager.ts
+++ b/src/managers/VerifyManager.ts
@@ -29,6 +29,7 @@ import { DungeonUtilities } from "../utilities/DungeonUtilities";
 import { TimeUtilities } from "../utilities/TimeUtilities";
 import { UserManager } from "./UserManager";
 import { QuotaManager } from "./QuotaManager";
+import * as Stream from "stream";
 
 export namespace VerifyManager {
     export const NUMBER_OF_STATS: number = 8;
@@ -97,8 +98,8 @@ export namespace VerifyManager {
      * @param {ISectionInfo} section The section where verification should occur.
      */
     export async function verify(
-        i: MessageComponentInteraction, 
-        guildDoc: IGuildInfo, 
+        i: MessageComponentInteraction,
+        guildDoc: IGuildInfo,
         section: ISectionInfo
     ): Promise<void> {
         // If they're in the process of verification, don't let them start.
@@ -120,8 +121,8 @@ export namespace VerifyManager {
             return;
         }
 
-        if (guildDoc.manualVerificationEntries.some(x => x.userId === i.user.id 
-                && x.sectionId === section.uniqueIdentifier)) {
+        if (guildDoc.manualVerificationEntries.some(x => x.userId === i.user.id
+            && x.sectionId === section.uniqueIdentifier)) {
             await i.reply({
                 content: "You have a pending manual verificaton application here. Please try again later.",
                 ephemeral: true
@@ -464,6 +465,11 @@ export namespace VerifyManager {
             nameToVerify = selected;
         }
 
+        if (!instance.section.otherMajorConfig.verificationProperties.useDefault) {
+            forcedManualVerify(msg, dmChan, instance, nameToVerify).then();
+            return;
+        }
+
         // We have a name now. This is where we tell them to put a code into their RealmEye description and
         // all of that.
         const verificationCode = StringUtil.generateRandomString(20);
@@ -793,7 +799,7 @@ export namespace VerifyManager {
 
                 await i.editReply({
                     content: "Something went wrong when fully reviewing your profile. Please resolve these issues"
-                    + ` and try again.\n${checkRes.taIssues.map(x => `- ${x.value}`).join("\n")}`
+                        + ` and try again.\n${checkRes.taIssues.map(x => `- ${x.value}`).join("\n")}`
                 });
 
                 instance.verifyFailChannel?.send({
@@ -812,7 +818,7 @@ export namespace VerifyManager {
             });
             await GlobalFgrUtilities.tryExecuteAsync(async () => {
                 await instance.member.setNickname(
-                    UserManager.getNameForNickname(instance.member, generalData.name), 
+                    UserManager.getNameForNickname(instance.member, generalData.name),
                     "Verified in the main section successfully."
                 );
             });
@@ -857,10 +863,12 @@ export namespace VerifyManager {
      * @private
      */
     async function verifySection(interaction: MessageComponentInteraction, instance: IVerificationInstance): Promise<void> {
-        if (!instance.section.otherMajorConfig.verificationProperties.checkRequirements) {
+        if (!instance.section.otherMajorConfig.verificationProperties.checkRequirements
+            // This conditional is required so users don't just bypass manual verification if explicitly asked for
+            && instance.section.otherMajorConfig.verificationProperties.useDefault) {
             await GlobalFgrUtilities.tryExecuteAsync(async () => {
                 await instance.member.roles.add(
-                    instance.section.roles.verifiedRoleId, 
+                    instance.section.roles.verifiedRoleId,
                     `Verified automatically in the ${instance.section.sectionName} section.`
                 );
             });
@@ -906,6 +914,28 @@ export namespace VerifyManager {
         }
         else {
             nameToUse = names[0];
+        }
+
+        if (!instance.section.otherMajorConfig.verificationProperties.useDefault) {
+            // First, we need to see if the person can be DMed.
+            const msgDmResp = await dmMember(instance.member);
+            if (!msgDmResp) {
+                await interaction.editReply({
+                    content: "I am not able to directly message you. Please make sure anyone in this server can DM you."
+                });
+
+                InteractivityManager.IN_VERIFICATION.delete(interaction.user.id);
+                return;
+            }
+
+            await interaction.editReply({
+                content: "Please check your direct messages for further instructions."
+            });
+
+            // Okay, that person can be DMed. Let's begin the process.
+            const [msg, dmChan] = msgDmResp;
+            forcedManualVerify(msg, dmChan, instance, nameToUse).then();
+            return;
         }
 
         const requestData = await GlobalFgrUtilities.tryExecuteAsync<PAD.IPlayerData>(async () => {
@@ -987,6 +1017,215 @@ export namespace VerifyManager {
         InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
     }
 
+    /**
+     * Runs the forced manual verification process.
+     * @param {Message} msg The message that was initially sent to the user. Assumed to exist.
+     * @param {DMChannel} dmChan The DM channel.
+     * @param {IVerificationInstance} instance The verification instance.
+     * @param {string} The name to use here.
+     */
+    async function forcedManualVerify(
+        msg: Message,
+        dmChan: DMChannel,
+        instance: IVerificationInstance,
+        nameToUse: string
+    ): Promise<void> {
+        const logType = instance.section.isMainSection
+            ? "`[Main]`"
+            : `\`[${instance.section.sectionName}]\``;
+
+        const guild = instance.member.guild;
+        const baseEmbed = MessageUtilities.generateBlankEmbed(instance.member.user, "RED");
+
+        const blUserInfo = instance.guildDoc.moderation.blacklistedUsers
+            .find(x => x.realmName.lowercaseIgn === nameToUse.toLowerCase());
+        if (blUserInfo) {
+            await MessageUtilities.tryEdit(msg, {
+                content: null,
+                embeds: [
+                    new MessageEmbed(baseEmbed)
+                        .setTitle(`**${instance.member.guild.name}**: Guild Verification Error.`)
+                        .setDescription("You are blacklisted from this server.")
+                        .addField("Blacklist Reason", blUserInfo.reason)
+                        .addField("Moderation ID", StringUtil.codifyString(blUserInfo.actionId))
+                        .setTimestamp()
+                ],
+                components: []
+            });
+
+            await instance.verifyFailChannel?.send({
+                content: `\`[Main]\` ${instance.member} tried to verify as **\`${nameToUse}\`**, but they are`
+                    + " blacklisted from this server under that name. The corresponding Moderation ID is"
+                    + ` \`${blUserInfo.actionId}\`.`,
+                allowedMentions: { roles: [], users: [] }
+            });
+
+            InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
+            return;
+        }
+
+        if (instance.section.isMainSection) {
+            baseEmbed.setTitle(`**${guild.name}**: Guild Verification`);
+        }
+        else {
+            baseEmbed.setTitle(`${guild.name} ⇨ **${instance.section.sectionName}**: Section Verification`);
+        }
+
+        const instructions = instance.section.otherMajorConfig.verificationProperties.instructionsManualVerification;
+        const r = await MessageUtilities.tryEdit(msg, {
+            content: null,
+            embeds: [
+                new MessageEmbed(baseEmbed)
+                    .setDescription(
+                        new StringBuilder()
+                            .append("Please upload **one** screenshot that satisfies the following directions:")
+                            .append(StringUtil.codifyString(instructions))
+                            .append("There will be __no__ opportunity for you to confirm your screenshot, so please")
+                            .append(" make sure you upload the correct screenshot.")
+                            .appendLine(2)
+                            .append("If you want to cancel this process, press the **Cancel** button.")
+                            .toString()
+                    )
+                    .setFooter({ text: "This process will expire by" })
+                    .setTimestamp(Date.now() + 4 * 60 * 1000)
+            ],
+            components: AdvancedCollector.getActionRowsFromComponents([
+                ButtonConstants.CANCEL_BUTTON
+            ])
+        });
+
+        if (!r) {
+            instance.verifyStepChannel?.send({
+                content: `${logType} ${instance.member} was asked to upload a screenshot, but something went wrong`
+                    + " when trying to edit the base embed message.",
+                allowedMentions: { roles: [], users: [] }
+            });
+
+            InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
+            msg.delete().catch();
+            return;
+        }
+
+        const imageRes = await AdvancedCollector.startDoubleCollector<Buffer | Stream | string>({
+            acknowledgeImmediately: true,
+            cancelFlag: null,
+            clearInteractionsAfterComplete: false,
+            deleteBaseMsgAfterComplete: false,
+            deleteResponseMessage: false,
+            duration: 4 * 60 * 1000,
+            oldMsg: msg,
+            targetAuthor: instance.member,
+            targetChannel: dmChan
+        }, async m => {
+            if (m.attachments.size === 0) {
+                return;
+            }
+
+            const at = m.attachments.first()!;
+            if (!at.height) {
+                return;
+            }
+
+            setTimeout(() => {
+                m.delete();
+            }, 5 * 1000);
+            return at.attachment;
+        });
+
+        if (!imageRes || imageRes instanceof MessageComponentInteraction) {
+            instance.verifyStepChannel?.send({
+                content: `${logType} ${instance.member} has canceled the manual verification process.`,
+                allowedMentions: { roles: [], users: [] }
+            });
+
+            InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
+            msg.delete().catch();
+            return;
+        }
+
+        const storageChannel = GlobalFgrUtilities.getCachedChannel<TextChannel>(instance.guildDoc.channels.storageChannelId);
+        if (!storageChannel) {
+            instance.verifyStepChannel?.send({
+                content: `${logType} ${instance.member} tried to upload an image for manual verification,`
+                    + " but the storage channel for the server is not defined or has been deleted.",
+                allowedMentions: { roles: [], users: [] }
+            });
+
+            InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
+            msg.delete().catch();
+            await GlobalFgrUtilities.sendMsg(dmChan, {
+                content: "The manual verification process could not be completed due to a configuation issue."
+            });
+
+            return;
+        }
+
+        const storedMsg = await storageChannel.send({
+            files: [imageRes],
+            content: new StringBuilder()
+                .append(`Upload Time: ${TimeUtilities.getDateTime()} GMT`).appendLine()
+                .append(`Uploaded By: ${instance.member}`).appendLine()
+                .append("Reason: Manual Verification")
+                .toString()
+        });
+
+        const attachedImage = storedMsg.attachments.first()!;
+        const descSb = new StringBuilder()
+            .append("The following user tried to get manually verified in the section:")
+            .append(` **\`${instance.section.sectionName}\`**.`)
+            .appendLine()
+            .appendLine()
+            .append("__**Discord Account**__").appendLine()
+            .append(`- Discord Mention: ${instance.member} (${instance.member.id})`).appendLine()
+            .append(`- Discord Tag: ${instance.member.user.tag}`).appendLine()
+            .append(`- Discord Created: ${TimeUtilities.getDateTime(instance.member.user.createdAt)} GMT`).appendLine();
+
+        const embed = MessageUtilities.generateBlankEmbed(instance.member, "YELLOW")
+            .setTitle(`[${instance.section.sectionName}] Automated Manual Verification`)
+            .setDescription(descSb.toString())
+            .setImage(attachedImage.url)
+            .addField(
+                "Reason(s) for Manual Verification",
+                "Required by server verification configuration."
+            );
+
+        // manualVerifyChannel exists because we asserted this in the checkRequirements function.
+        const manualVerifMsg = await instance.manualVerifyChannel!.send({
+            embeds: [embed],
+            components: AdvancedCollector.getActionRowsFromComponents([
+                new MessageButton()
+                    .setLabel("Accept")
+                    .setCustomId(MANUAL_VERIFY_ACCEPT_ID)
+                    .setEmoji(EmojiConstants.GREEN_CHECK_EMOJI)
+                    .setStyle("SUCCESS"),
+                new MessageButton()
+                    .setLabel("Deny")
+                    .setCustomId(MANUAL_VERIFY_DENY_ID)
+                    .setEmoji(EmojiConstants.X_EMOJI)
+                    .setStyle("DANGER")
+            ])
+        });
+
+        await MongoManager.updateAndFetchGuildDoc({ guildId: guild.id }, {
+            $push: {
+                manualVerificationEntries: {
+                    userId: instance.member.id,
+                    ign: nameToUse,
+                    manualVerifyMsgId: manualVerifMsg.id,
+                    manualVerifyChannelId: instance.manualVerifyChannel!.id,
+                    sectionId: instance.section.uniqueIdentifier
+                }
+            }
+        });
+
+        instance.verifyStepChannel?.send({
+            content: `${logType} ${instance.member} has successfully sent a manual verification request.`,
+            allowedMentions: { roles: [], users: [] }
+        });
+
+        InteractivityManager.IN_VERIFICATION.delete(instance.member.id);
+    }
+
 
     /**
      * Handles the case when manual verification is needed. Note that you need to handle the case of removing the 
@@ -999,8 +1238,11 @@ export namespace VerifyManager {
      * to already.
      * @private
      */
-    async function handleManualVerification(instance: IVerificationInstance, checkRes: IReqCheckResult,
-                                            from: TextBasedChannel | MessageComponentInteraction): Promise<void> {
+    async function handleManualVerification(
+        instance: IVerificationInstance, 
+        checkRes: IReqCheckResult,
+        from: TextBasedChannel | MessageComponentInteraction
+    ): Promise<void> {
         const guild = instance.member.guild;
         const section = instance.section;
         const logStr = checkRes.manualIssues.map(x => `- [${x.key}] ${x.log}`).join("\n");
@@ -1242,9 +1484,9 @@ export namespace VerifyManager {
      * @param origMsg The original message, if any.
      */
     export async function acknowledgeManualVerif(
-        entry: IManualVerificationEntry, 
-        mod: GuildMember, 
-        responseId: string, 
+        entry: IManualVerificationEntry,
+        mod: GuildMember,
+        responseId: string,
         origMsg?: Message
     ): Promise<void> {
         const manualVerifChannel = GuildFgrUtilities.getCachedChannel<TextChannel>(
@@ -1292,7 +1534,7 @@ export namespace VerifyManager {
 
         // Okay, get the section associated with the entry.
         let section = guildDoc.guildSections.find(x => x.uniqueIdentifier === entry.sectionId);
-        
+
         // If no section found, then we have two cases.
         if (!section) {
             // if the section ID isn't the main section, then we can just clear everything
@@ -1330,7 +1572,7 @@ export namespace VerifyManager {
             mod.guild,
             guildDoc.channels.loggingChannels.find(x => x.key === "VerifyFail")?.value ?? ""
         );
-        
+
         // Now, let's respond based on the response ID.
         const promises: (Promise<unknown> | undefined)[] = [];
 
@@ -1368,12 +1610,12 @@ export namespace VerifyManager {
                 if (section.isMainSection) {
                     await GlobalFgrUtilities.tryExecuteAsync(async () => {
                         await member.setNickname(
-                            UserManager.getNameForNickname(member, entry.ign), 
+                            UserManager.getNameForNickname(member, entry.ign),
                             `Manually verified in the main section successfully by ${mod.user.tag}`
                         );
                     });
-                    await MongoManager.addIdNameToIdNameCollection(member, entry.ign);    
-                                    
+                    await MongoManager.addIdNameToIdNameCollection(member, entry.ign);
+
                     promises.push(
                         verifySuccessChannel?.send({
                             content: `\`[Main]\` ${member} has successfully verified as **\`${entry.ign}\`**`
@@ -1400,14 +1642,14 @@ export namespace VerifyManager {
                                 .setColor("DARK_GREEN")
                                 .addField("Status", `Accepted by ${mod.toString()} (${mod.user.tag}).`)
                         ]
-                    }); 
+                    });
                 }
 
                 break;
             }
             case (MANUAL_VERIFY_DENY_ID): {
                 promises.push(
-                    GlobalFgrUtilities.sendMsg(member, { 
+                    GlobalFgrUtilities.sendMsg(member, {
                         embeds: [
                             MessageUtilities.generateBlankEmbed(mod.guild, "RED")
                                 .setTitle(
@@ -1420,14 +1662,14 @@ export namespace VerifyManager {
                                     "Your manual verification request was **denied**. If you have any questions regarding"
                                     + " why your request was denied, please message a staff member or send a modmail."
                                 )
-                        ] 
+                        ]
                     }),
                     verifyFailChannel?.send({
                         content: section.isMainSection
                             ? `\`[Main]\` ${member} has tried to verify as **\`${entry.ign}\`**, but`
-                                + ` their manual verification request was __denied__ by ${mod}.`
+                            + ` their manual verification request was __denied__ by ${mod}.`
                             : `\`[${section.sectionName}]\` ${member} has tried to get manually verified, but`
-                                + ` was __denied__ manual verification by ${mod}.`,
+                            + ` was __denied__ manual verification by ${mod}.`,
                         allowedMentions: { roles: [], users: [] }
                     })
                 );
@@ -1441,7 +1683,7 @@ export namespace VerifyManager {
                                 .setColor("DARK_RED")
                                 .addField("Status", `Rejected by ${mod.toString()} (${mod.user.tag}).`)
                         ]
-                    }); 
+                    });
                 }
 
                 break;
@@ -1509,7 +1751,7 @@ export namespace VerifyManager {
 
         // Check guild. Failure to pass these tests will result in a fail.
         if (verifReq.guild.checkThis) {
-            if (verifReq.guild.guildName.checkThis 
+            if (verifReq.guild.guildName.checkThis
                 && (!resp.guild || resp.guild.toLowerCase() !== verifReq.guild.guildName.name.toLowerCase())) {
                 const guildInDisplay = `**\`${resp.guild}\`**`;
                 const guildNeededDisplay = `**\`${verifReq.guild.guildName.name}\`**`;
@@ -1898,10 +2140,10 @@ export namespace VerifyManager {
             .addField(
                 "3. Wait.",
                 "Please wait at least **30 seconds** after applying the above changes. In particular, if you *just* made your"
-                    + " last seen location private, updated your RealmEye description, or made parts (or all) of your profile"
-                    + " public, it is strongly recommended that you wait, since RealmEye takes time to update.\n\n"
-                    + `${EmojiConstants.WARNING_EMOJI} **Warning:** Failure to wait after making the above changes will result`
-                    + " in the bot not properly registering your changes for the next minute or so after your next attempt.",
+                + " last seen location private, updated your RealmEye description, or made parts (or all) of your profile"
+                + " public, it is strongly recommended that you wait, since RealmEye takes time to update.\n\n"
+                + `${EmojiConstants.WARNING_EMOJI} **Warning:** Failure to wait after making the above changes will result`
+                + " in the bot not properly registering your changes for the next minute or so after your next attempt.",
             )
             .addField(
                 "4. Confirm",
@@ -1947,16 +2189,16 @@ export namespace VerifyManager {
                     .append(checkPastDeaths ? " (Past Deaths Allowed)." : ".").appendLine();
             }
         }
-    
+
         if (verifProps.verifReq.exaltations.checkThis) {
             let added = false;
             for (const stat in verifProps.verifReq.exaltations.minimum) {
                 if (!verifProps.verifReq.exaltations.minimum.hasOwnProperty(stat))
                     continue;
-    
+
                 const numNeeded = verifProps.verifReq.exaltations.minimum[stat];
                 if (numNeeded === 0) continue;
-                    // Put here so this shows up first on list
+                // Put here so this shows up first on list
                 if (!added) {
                     sb.append("- Exaltations are Public.").appendLine();
                     added = true;
@@ -1964,11 +2206,11 @@ export namespace VerifyManager {
                 const displayedVersion = SHORT_STAT_TO_LONG[stat][1];
                 sb.append(`- ${numNeeded} ${displayedVersion} Exaltations.`).appendLine();
             }
-    
+
             if (added && verifProps.verifReq.exaltations.onOneChar)
                 sb.append("- Exaltations Must Be On One Character.").appendLine();
         }
-    
+
         if ((verifProps.verifReq.dungeonCompletions?.length ?? 0) > 0) {
             for (const entry of verifProps.verifReq.dungeonCompletions ?? []) {
                 if (entry.value === 0) continue;
@@ -1977,7 +2219,7 @@ export namespace VerifyManager {
                 sb.append(`- ${entry.value} ${dgnInfo.dungeonName} Completion Logged.`).appendLine();
             }
         }
-    
+
         return sb.toString().trim();
     }
 
@@ -1990,7 +2232,7 @@ export namespace VerifyManager {
      */
     export async function removeAllManualVerifAppsForUser(guild: Guild, userId: string): Promise<void> {
         const guildDoc = await MongoManager.getOrCreateGuildDoc(guild, true);
-        
+
         // Delete all manual verification request messages by this person.
         await Promise.all([
             guildDoc.manualVerificationEntries
@@ -2003,12 +2245,12 @@ export namespace VerifyManager {
                     if (!channel) {
                         return;
                     }
-        
+
                     const relevantMsg = await GuildFgrUtilities.fetchMessage(channel, x.manualVerifyMsgId);
                     if (!relevantMsg) {
                         return;
                     }
-        
+
                     await MessageUtilities.tryDelete(relevantMsg);
                 })
         ]);

--- a/src/managers/VerifyManager.ts
+++ b/src/managers/VerifyManager.ts
@@ -1032,7 +1032,7 @@ export namespace VerifyManager {
                 components: []
             });
 
-            await instance.verifyFailChannel?.send({
+            await instance.verifyStepChannel?.send({
                 content: `\`[Main]\` ${instance.member} tried to verify as **\`${nameToUse}\`**, but they are`
                     + " blacklisted from this server under that name. The corresponding Moderation ID is"
                     + ` \`${blUserInfo.actionId}\`.`,

--- a/src/utilities/Logger.ts
+++ b/src/utilities/Logger.ts
@@ -14,7 +14,7 @@ export class Logger {
      * @param {string} fileName The file using the logger. Use `__filename`.
      * @param {boolean} debug Whether to output DEBUG messages, default = false
      */
-    public constructor(fileName: string, debug = false) {
+    public constructor(fileName: string, debug: boolean = false) {
         this.path = path.basename(fileName);
         this.formattedPath = `[${this.path}]`;
         this.outputDebug = debug;


### PR DESCRIPTION
This PR adds the ability for verification to be done 100% manually. To be explicit, rather than having the bot automatically verify members by checking their RealmEye profile, staff members now have the ability to configure the bot so the bot asks the user for a screenshot (perhaps, of them in their vault saying their Discord tag); once the bot gets the screenshot, this screenshot will be sent to the manual verification channel, where a staff member can look at it.