### PR TITLE
feat(api): removed properties that the realmeye api no longer returns

### DIFF
--- a/src/private-api/PrivateApiDefinitions.ts
+++ b/src/private-api/PrivateApiDefinitions.ts
@@ -137,7 +137,6 @@ export namespace PrivateApiDefinitions {
             };
             characterType: string;
             level: number;
-            classQuestsCompleted: number;
             fame: number;
             place: number;
             equipmentData: {

--- a/src/private-api/PrivateApiDefinitions.ts
+++ b/src/private-api/PrivateApiDefinitions.ts
@@ -115,7 +115,6 @@ export namespace PrivateApiDefinitions {
         characterCount: number;
         skins: number;
         fame: number;
-        exp: number;
         rank: number;
         accountFame: number;
         guild?: string;
@@ -140,7 +139,6 @@ export namespace PrivateApiDefinitions {
             level: number;
             classQuestsCompleted: number;
             fame: number;
-            experience: number;
             place: number;
             equipmentData: {
                 name: string;


### PR DESCRIPTION
RealmEye recently removed CQC and experience from player and guild profiles. I updated the [API](https://github.com/ToogaInc/RealmEyeSharper/pull/10) to account for this, but also need to update it here on the bot.