### PR TITLE
Support for QuotaPoints

### DIFF
--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -195,7 +195,8 @@ export class Bot {
             new Cmds.LogRun(),
             new Cmds.LogKey(),
             new Cmds.LogParse(),
-            new Cmds.GivePoints()
+            new Cmds.GivePoints(),
+            new Cmds.AddQuotaPoints()
         ]);
 
         Bot.Commands.set("Modmail", [

--- a/src/commands/general/Stats.ts
+++ b/src/commands/general/Stats.ts
@@ -149,7 +149,9 @@ export class Stats extends BaseCommand {
 
         const pts = await LoggerManager.getPoints((resMember as IResolvedMember).member);
         let description = `${EmojiConstants.TICKET_EMOJI} Points: ${pts}`;
-        if(stats.quotaPoints > 0) description +=`\nQuota Points: ${stats.quotaPoints}`;
+        if(stats.quotaPoints > 0) {
+            description +=`\nQuota Points: ${stats.quotaPoints}`;
+        }
 
         if (ctx.guild && !showAll) {            
 

--- a/src/commands/general/Stats.ts
+++ b/src/commands/general/Stats.ts
@@ -147,10 +147,14 @@ export class Stats extends BaseCommand {
             }
         };
 
-        if (ctx.guild && !showAll) {
-            const pts = await LoggerManager.getPoints((resMember as IResolvedMember).member);
+        const pts = await LoggerManager.getPoints((resMember as IResolvedMember).member);
+        let description = `${EmojiConstants.TICKET_EMOJI} Points: ${pts}`;
+        if(stats.quotaPoints > 0) description +=`\nQuota Points: ${stats.quotaPoints}`;
+
+        if (ctx.guild && !showAll) {            
+
             embed.setTitle(`Stats for **${user.tag}** in **${ctx.guild!}**`)
-                .setDescription(`${EmojiConstants.TICKET_EMOJI} Points: ${pts}`);
+                .setDescription(description);
 
             const dungeonsLed = stats.dungeonsLed.get(ctx.guild.id);
             if (dungeonsLed) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -48,6 +48,7 @@ export * from "./logging/LogRun";
 export * from "./logging/LogKey";
 export * from "./logging/LogParse";
 export * from "./logging/GivePoints";
+export * from "./logging/AddQuotaPoints";
 
 export * from "./owner/SetStatus";
 

--- a/src/commands/logging/AddQuotaPoints.ts
+++ b/src/commands/logging/AddQuotaPoints.ts
@@ -1,0 +1,80 @@
+import { ArgumentType, BaseCommand, ICommandContext, ICommandInfo } from "../BaseCommand";
+import { UserManager } from "../../managers/UserManager";
+import { MongoManager } from "../../managers/MongoManager";
+import { QuotaManager } from "../../managers/QuotaManager";
+
+export class AddQuotaPoints extends BaseCommand {
+    public constructor() {
+        const cmi: ICommandInfo = {
+            cmdCode: "ADD_QUOTA_POINTS_COMMAND",
+            formalCommandName: "Add Quota Points Command",
+            botCommandName: "addquotapoints",
+            description: "Adds quota points to a member, defaulting to yourself.  Use negative number to remove points.",
+            commandCooldown: 0,
+            generalPermissions: [],
+            argumentInfo: [
+                {
+                    displayName: "Member",
+                    argName: "member",
+                    desc: "The member to give points to. If no member is specified, this will give points to you.",
+                    type: ArgumentType.String,
+                    prettyType: "Member Resolvable (ID, Mention, IGN)",
+                    required: false,
+                    example: ["@Console#8939", "123313141413155", "Darkmattr"]
+                },
+                {
+                    displayName: "Points",
+                    argName: "points",
+                    desc: "The number of points to give.",
+                    type: ArgumentType.Integer,
+                    prettyType: "Integer",
+                    required: true,
+                    example: ["5"]
+                }
+            ],
+            botPermissions: [],
+            rolePermissions: [
+                "HeadRaidLeader",
+                "Officer",
+                "Moderator"
+            ],
+            guildOnly: true,
+            botOwnerOnly: false
+        };
+
+        super(cmi);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public async run(ctx: ICommandContext): Promise<number> {
+        const mStr = ctx.interaction.options.getString("member", false);
+        const points = ctx.interaction.options.getInteger("points", false) ?? 20;
+
+        if (points === 0) {
+            await ctx.interaction.reply({
+                ephemeral: true,
+                content: "You aren't logging anything."
+            });
+
+            return 0;
+        }
+
+        // See if there is another member to log as. We also need to make sure
+        // there is a database entry available
+        const resMember = mStr
+            ? (await UserManager.resolveMember(ctx.guild!, mStr))?.member ?? ctx.member!
+            : ctx.member!;
+        await MongoManager.addIdNameToIdNameCollection(resMember);
+        await MongoManager.getOrCreateUserDoc(resMember.id);
+        const resultDoc = await QuotaManager.addQuotaPts(resMember, points);
+        await ctx.interaction.reply({
+            components: [],
+            content: `Added \`${points}\` point(s) to ${resMember} for a new total of ${resultDoc.value?.details.quotaPoints}.`,
+            embeds: []
+        });
+
+        return 0;
+    }
+}

--- a/src/commands/logging/AddQuotaPoints.ts
+++ b/src/commands/logging/AddQuotaPoints.ts
@@ -71,7 +71,7 @@ export class AddQuotaPoints extends BaseCommand {
         const resultDoc = await QuotaManager.addQuotaPts(resMember, points);
         await ctx.interaction.reply({
             components: [],
-            content: `Added \`${points}\` point(s) to ${resMember} for a new total of ${resultDoc.value?.details.quotaPoints}.`,
+            content: `Added \`${points}\` point(s) to ${resMember} for a new total of ${resultDoc?.details.quotaPoints}.`,
             embeds: []
         });
 

--- a/src/definitions/MongoDocumentInterfaces.ts
+++ b/src/definitions/MongoDocumentInterfaces.ts
@@ -758,6 +758,11 @@ export interface IUserInfo {
          * @type {string}
          */
         universalNotes: string;
+
+        /**
+         * Quota points, because this is how we implement new features :)
+         */
+        quotaPoints: number;
     };
 }
 

--- a/src/managers/LoggerManager.ts
+++ b/src/managers/LoggerManager.ts
@@ -46,6 +46,11 @@ export namespace LoggerManager {
          * where the key is the dungeon name (not ID) and the value is the number completed/failed/assisted.
          */
         dungeonsLed: Collection<string, DungeonLedType>;
+        
+        /**
+         * Total quota points, used for leader shop experience
+         */
+        quotaPoints: number;
     }
 
     /**
@@ -247,6 +252,7 @@ export namespace LoggerManager {
 
         const stats: IUserStats = {
             keyUse: new Collection<string, Collection<string, number>>(),
+            quotaPoints: userInfo.details.quotaPoints,
             dungeonsLed: new Collection<string, Collection<string, {
                 completed: number;
                 failed: number;

--- a/src/managers/LoggerManager.ts
+++ b/src/managers/LoggerManager.ts
@@ -48,7 +48,8 @@ export namespace LoggerManager {
         dungeonsLed: Collection<string, DungeonLedType>;
         
         /**
-         * Total quota points, used for leader shop experience
+         * Cumulative quota points.  This property is automatically increased during quota logging, and can be 
+         * manually adjusted through the AddQuotaPoints command.
          */
         quotaPoints: number;
     }

--- a/src/managers/MongoManager.ts
+++ b/src/managers/MongoManager.ts
@@ -555,7 +555,7 @@ export namespace MongoManager {
      */
     export function getDefaultUserConfig(userId: string): IUserInfo {
         return {
-            details: { moderationHistory: [], universalNotes: "", guildNotes: [] },
+            details: { moderationHistory: [], universalNotes: "", guildNotes: [], quotaPoints: 0 },
             discordId: userId,
             loggedInfo: []
         };

--- a/src/managers/QuotaManager.ts
+++ b/src/managers/QuotaManager.ts
@@ -473,6 +473,12 @@ export namespace QuotaManager {
         await addQuotaPts(member, amt);
     }
 
+    /**
+     * Adds value to the user's quotaPoints
+     * @param {GuildMember} member The member to log for.
+     * @param {number} pts the number of poitns to add.
+     * @returns {IUserInfo | null} the updated IUserInfo
+     */
     export async function addQuotaPts(member: GuildMember, pts: number){
         const userDoc = await MongoManager.getOrCreateUserDoc(member.id);
         let newPts = pts;
@@ -490,7 +496,7 @@ export namespace QuotaManager {
         },{
             returnDocument: "after"
         });
-        return returnDoc;
+        return returnDoc?.value;
     }
 
     /**

--- a/src/managers/QuotaManager.ts
+++ b/src/managers/QuotaManager.ts
@@ -470,7 +470,21 @@ export namespace QuotaManager {
                 }
             }
         });
-        await addQuotaPts(member, amt);
+        const guildDoc = await MongoManager.getOrCreateGuildDoc(member.guild, true);
+        const quotaInfo = guildDoc.quotas.quotaInfo.find(x => x.roleId === roleId);
+        if(!quotaInfo) return;
+
+        let quotaPoints = (quotaInfo.pointValues.find(x => x.key === logType)?.value ?? 0) * amt;
+        if (logType.startsWith("Run")) {
+            // See if we have RunComplete for all dungeons instead of specific dungeons
+            const baseLogType = logType.split(":")[0];
+            const quotaRule = quotaInfo.pointValues.find(x => x.key === baseLogType);
+            if (quotaRule) {
+                quotaPoints = quotaRule.value * amt;
+            }
+        }
+
+        await addQuotaPts(member, quotaPoints);
     }
 
     /**

--- a/src/managers/QuotaManager.ts
+++ b/src/managers/QuotaManager.ts
@@ -470,6 +470,27 @@ export namespace QuotaManager {
                 }
             }
         });
+        await addQuotaPts(member, amt);
+    }
+
+    export async function addQuotaPts(member: GuildMember, pts: number){
+        const userDoc = await MongoManager.getOrCreateUserDoc(member.id);
+        let newPts = pts;
+        if(!isNaN(userDoc.details.quotaPoints)){
+            newPts += userDoc.details.quotaPoints;
+        }
+        LOGGER.info(`Adding ${pts} points to ${member.displayName} for a total of ${(newPts > 0) ? newPts : 0}`);
+        
+        const returnDoc = await MongoManager.getUserCollection().findOneAndUpdate({
+            discordId: member.id
+        },{
+            $set:{
+                "details.quotaPoints": (newPts > 0) ? newPts : 0
+            }
+        },{
+            returnDocument: "after"
+        });
+        return returnDoc;
     }
 
     /**


### PR DESCRIPTION
Support for QuotaPoints, for purposes of a leader shop system.

- Each UserDoc tracks a user's quota points in details.quotaPoints
- When quota is logged by any means, the points are automatically added to the user's quotaPoints
- AddQuotaPoints command for use by HRL, Officer, Mod can add positive or negative points
- Stats shows user's quota points