### PR TITLE
fix: cmds that errored no longer locks user out

### DIFF
--- a/src/events/InteractionEvent.ts
+++ b/src/events/InteractionEvent.ts
@@ -123,9 +123,19 @@ async function slashCommandHandler(interaction: CommandInteraction, guildDoc?: I
         foundCommand.addToCooldown(ctx.user);
 
     if (canRunInfo.canRun) {
-        foundCommand.addActiveUser(ctx.user.id, ctx.guild?.id);
-        await foundCommand.run(ctx);
-        foundCommand.removeActiveUser(ctx.user.id, ctx.guild?.id);
+        try {
+            foundCommand.addActiveUser(ctx.user.id, ctx.guild?.id);
+            await foundCommand.run(ctx);
+        }
+        catch (e) {
+            // Log any errors that we get.
+            LOGGER.error(`[${foundCommand.commandInfo.botCommandName}] ${e}`);
+        }
+        finally {
+            // Even if an error is thrown, the finally block should catch it and remove them.
+            foundCommand.removeActiveUser(ctx.user.id, ctx.guild?.id);
+        }
+
         return;
     }
 


### PR DESCRIPTION
Before, users that ran a command (that limited the number of active users) that threw an error would not be allowed to run that command again until the bot is restarted (they would get an "Already Using Command" error from the bot). 

This PR should fix that issue.