### PR TITLE
Added 'Steamworks' and 'Sulfurous Wetlands' Dungeons.

### DIFF
--- a/src/commands/raid-leaders/StartHeadcount.ts
+++ b/src/commands/raid-leaders/StartHeadcount.ts
@@ -29,12 +29,14 @@ export class StartHeadcount extends BaseCommand {
                     type: ArgumentType.String,
                     restrictions: {
                         stringChoices: [
+                            { name: "steamworks", value: "STEAMWORKS" },
                             { name: "o3", value: "ORYX_3" },
                             { name: "shatts", value: "SHATTERS" },
                             { name: "nest", value: "NEST" },
-                            { name: "cult", value: "CULTIST_HIDEOUT" },
                             { name: "fungal", value: "FUNGAL_CAVERN" },
-                            { name: "void", value: "THE_VOID" }
+                            { name: "cult", value: "CULTIST_HIDEOUT" },
+                            { name: "void", value: "THE_VOID" },
+                            { name: "lost halls", value: "LOST_HALLS" }
                         ]
                     },
                     prettyType: "Dungeon name (one word: o3, oryx, shatts, shatters)",

--- a/src/constants/EmojiConstants.ts
+++ b/src/constants/EmojiConstants.ts
@@ -103,7 +103,7 @@ export namespace EmojiConstants {
 
     export const DPS_WIZARD: string = "929851498442133554";
     export const DPS_RANGED: string = "992973584182022174";
-    export const DPS_GENERAL: string = "992973560068980858";
+    export const DPS_GENERAL: string = "1001206102098190478";
 
     // status effects
     export const PARALYZE: string = "678792068906352642";

--- a/src/constants/dungeons/DungeonData.ts
+++ b/src/constants/dungeons/DungeonData.ts
@@ -2,6 +2,38 @@ import { IDungeonInfo } from "../../definitions";
 
 export const DUNGEON_DATA: readonly IDungeonInfo[] = [
     {
+        codeName: "WETLANDS_KEY",
+        dungeonName: "Sulfurous Wetlands",
+        portalEmojiId: "1051564126637391872",
+        keyReactions: [
+            {
+                mapKey: "WETLANDS_KEY",
+                maxEarlyLocation: 5
+            }
+        ],
+        otherReactions: [],
+        portalLink: {
+            url: "https://i.imgur.com/s2mWQQq.png",
+            name: "Sulfurous Wetlands Portal"
+        },
+        bossLinks: [
+            {
+                url: "https://i.imgur.com/9reqR1p.png",
+                name: "Heart of the Wetlands"
+            },
+            {
+                url: "https://i.imgur.com/kopUOQw.png",
+                name: "Warped Ent Ancient"
+            }
+        ],
+        dungeonColors: [
+            0x008000,
+            0x800000
+        ],
+        dungeonCategory: "Godland Dungeons",
+        isBuiltIn: true
+    },
+    {
         codeName: "SNAKE_PIT",
         dungeonName: "Snake Pit",
         portalEmojiId: "561248700291088386",
@@ -1086,6 +1118,82 @@ export const DUNGEON_DATA: readonly IDungeonInfo[] = [
             0x2a852a
         ],
         dungeonCategory: "Mini Dungeons",
+        isBuiltIn: true
+    },
+    {
+        codeName: "STEAMWORKS",
+        dungeonName: "Steamworks",
+        portalEmojiId: "1051549087574544404",
+        keyReactions: [
+            {
+                mapKey: "STEAMWORKS_KEY",
+                maxEarlyLocation: 2
+            }
+        ],
+        otherReactions: [
+            {
+                mapKey: "CURSE",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "FUNGAL_TOME",
+                maxEarlyLocation: 2
+            },
+            {
+                mapKey: "MSEAL",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "ARMOR_BREAK",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "WARRIOR",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "KNIGHT",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "PALADIN",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "TRICKSTER",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "MYSTIC",
+                maxEarlyLocation: 0
+            }
+        ],
+        portalLink: {
+            url: "https://i.imgur.com/ItKUC5A.png",
+            name: "Steamworks Portal"
+        },
+        bossLinks: [
+            {
+                url: "https://i.imgur.com/mK2gN3p.png",
+                name: "Core Form"
+            },
+            {
+                url: "https://i.imgur.com/Bvc5thY.png",
+                name: "Enforcer Form"
+            },
+            {
+                url: "https://i.imgur.com/a6SxEBx.png",
+                name: "Dragon Form"
+            }
+
+
+        ],
+        dungeonColors: [
+            0xC0C0C0,
+            0x808080,
+            0xFF00FF
+        ],
+        dungeonCategory: "Exaltation Dungeons",
         isBuiltIn: true
     },
     {

--- a/src/constants/dungeons/MappedAfkCheckReactions.ts
+++ b/src/constants/dungeons/MappedAfkCheckReactions.ts
@@ -325,6 +325,15 @@ export const MAPPED_AFK_CHECK_REACTIONS: IMappedAfkCheckReactions = {
 
 
     // Keys
+    WETLANDS_KEY: {
+        type: "KEY",
+        emojiInfo: {
+            isCustom: true,
+            identifier: "1051546644874797078"
+        },
+        name: "Sulfurous Wetlands Key",
+        isExaltKey: false
+        },
     SNAKE_PIT_KEY: {
         type: "KEY",
         emojiInfo: {
@@ -710,6 +719,15 @@ export const MAPPED_AFK_CHECK_REACTIONS: IMappedAfkCheckReactions = {
             identifier: "609078341529632778"
         },
         name: "Fungal Cavern Key",
+        isExaltKey: true
+    },
+    STEAMWORKS_KEY: {
+        type: "KEY",
+        emojiInfo: {
+            isCustom: true,
+            identifier: "1051549087574544404"
+        },
+        name: "Steamworks Key",
         isExaltKey: true
     },
     MISCELLANEOUS_DUNGEON_KEY: {


### PR DESCRIPTION
Also added Steamworks and Lost Halls as a choice for the "dungeon" argument in the /headcount command. (the thing that makes it go straight to the HC and avoids having to click more drop down menus)