### PR TITLE
fix: custom dungeons could not be added to quota/afk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tooga-booga",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A simple Discord bot for Realm of the Mad God servers, designed for verification and raid management. ",
   "main": "index.js",
   "scripts": {

--- a/src/commands/config/ConfigDungeons.ts
+++ b/src/commands/config/ConfigDungeons.ts
@@ -191,7 +191,7 @@ export class ConfigDungeons extends BaseCommand {
             bossLinks: dgn.bossLinks.map(x => {
                 return { ...x };
             }),
-            codeName: `[[${dgn.codeName}:${Date.now()}:${StringUtil.generateRandomString(5)}]]`,
+            codeName: `[[${dgn.codeName}-${Date.now()}-${StringUtil.generateRandomString(5)}]]`,
             dungeonCategory: dgn.dungeonCategory,
             dungeonColors: dgn.dungeonColors.slice(),
             dungeonName: dgn.dungeonName,

--- a/src/definitions/DungeonRaidInterfaces.ts
+++ b/src/definitions/DungeonRaidInterfaces.ts
@@ -434,7 +434,7 @@ export interface IAfkCheckProperties {
     /**
      * The default number of people that can get early location by reacting to the Nitro button.
      *
-     * Use `-1` to default to 8% of the VC limit.
+     * Use `-1` to default to 10% of the VC limit.
      *
      * This does not apply to priority reactions (key, class, etc.).
      *

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -422,6 +422,10 @@ export class RaidInstance {
             // If this is not a base or derived dungeon (i.e. it's a custom dungeon), then it must specify the nitro
             // limit.
             numEarlyLoc = (dungeon as ICustomDungeonInfo).nitroEarlyLocationLimit;
+            if (numEarlyLoc === -1) {
+                numEarlyLoc = section.otherMajorConfig.afkCheckProperties.nitroEarlyLocationLimit;
+            }
+
             costForEarlyLoc = (dungeon as ICustomDungeonInfo).pointCost;
             if ((dungeon as ICustomDungeonInfo).allowedModifiers) {
                 this._modifiersToUse = (dungeon as ICustomDungeonInfo).allowedModifiers
@@ -441,7 +445,8 @@ export class RaidInstance {
             else raidLimit = 45;
         }
 
-        if (numEarlyLoc === -2) {
+        // If numEarlyLoc is still -1 (or -2), then default to 10% of the VC cap. 
+        if (numEarlyLoc < 0) {
             numEarlyLoc = Math.max(Math.floor(raidLimit * 0.1), 1);
         }
 


### PR DESCRIPTION
Fixes two bugs:
- Custom dungeons should now work with AFK checks
- Custom dungeons should now work in quotas

@Deaththth 