### PR TITLE
feat: role pings for dungeons and afk-checks

### DIFF
--- a/src/commands/config/ConfigDungeons.ts
+++ b/src/commands/config/ConfigDungeons.ts
@@ -654,7 +654,7 @@ export class ConfigDungeons extends BaseCommand {
             .setCustomId("points_enter")
             .setStyle("PRIMARY");
         const mentionRolesButton = new MessageButton()
-            .setLabel("Roles to mention")
+            .setLabel("Roles to Mention")
             .setCustomId("mention_roles")
             .setStyle("PRIMARY");
         const nitroLimitButton = new MessageButton()
@@ -1224,6 +1224,7 @@ export class ConfigDungeons extends BaseCommand {
                     break;
                 }
                 case "mention_roles": {
+                    if (!cDungeon.mentionRoles) cDungeon.mentionRoles = [];
                     const mentionRoles = await this.configSetting<Role>(
                         ctx,
                         botMsg,

--- a/src/commands/config/ConfigDungeons.ts
+++ b/src/commands/config/ConfigDungeons.ts
@@ -656,7 +656,7 @@ export class ConfigDungeons extends BaseCommand {
             .setCustomId("points_enter")
             .setStyle("PRIMARY");
         const mentionRolesButton = new MessageButton()
-            .setLabel("Roles to Mention")
+            .setLabel("Roles to mention")
             .setCustomId("mention_roles")
             .setStyle("PRIMARY");
         const nitroLimitButton = new MessageButton()
@@ -1232,7 +1232,6 @@ export class ConfigDungeons extends BaseCommand {
                     break;
                 }
                 case "mention_roles": {
-                    if (!cDungeon.mentionRoles) cDungeon.mentionRoles = [];
                     const mentionRoles = await this.configSetting<Role>(
                         ctx,
                         botMsg,

--- a/src/commands/config/ConfigDungeons.ts
+++ b/src/commands/config/ConfigDungeons.ts
@@ -941,8 +941,8 @@ export class ConfigDungeons extends BaseCommand {
                         }
                     });
 
-                    const oldRoles = oldDungeonData?.mentionRoles.every(item => cDungeon.mentionRoles.includes(item));
-                    const newRoles = cDungeon.mentionRoles.every(item => (oldDungeonData as IDungeonOverrideInfo).mentionRoles.includes(item));
+                    const oldRoles = oldDungeonData?.mentionRoles?.every(item => cDungeon.mentionRoles.includes(item));
+                    const newRoles = cDungeon.mentionRoles?.every(item => (oldDungeonData as IDungeonOverrideInfo).mentionRoles.includes(item));
                     if (oldRoles && newRoles) {
                         ConfigChannels.createNewRolePingMessage(ctx.channel.client, ctx.guildDoc!);
                     }

--- a/src/commands/config/ConfigDungeons.ts
+++ b/src/commands/config/ConfigDungeons.ts
@@ -917,7 +917,7 @@ export class ConfigDungeons extends BaseCommand {
                     return;
                 }
                 case ButtonConstants.SAVE_ID: {
-                    let oldDungeonData;
+                    let oldDungeonData: IDungeonOverrideInfo | undefined;
                     if (dungeon) {
                         oldDungeonData = ctx.guildDoc?.properties.dungeonOverride.find(x => x.codeName === cDungeon.codeName);
                         ctx.guildDoc = await MongoManager.updateAndFetchGuildDoc({ guildId: ctx.guild!.id }, {
@@ -941,7 +941,9 @@ export class ConfigDungeons extends BaseCommand {
                         }
                     });
 
-                    if (oldDungeonData?.mentionRoles.sort().join(" ") !== cDungeon.mentionRoles.sort().join(" ")) {
+                    const oldRoles = oldDungeonData?.mentionRoles.every(item => cDungeon.mentionRoles.includes(item));
+                    const newRoles = cDungeon.mentionRoles.every(item => (oldDungeonData as IDungeonOverrideInfo).mentionRoles.includes(item));
+                    if (oldRoles && newRoles) {
                         ConfigChannels.createNewRolePingMessage(ctx.channel.client, ctx.guildDoc!);
                     }
 

--- a/src/commands/config/ConfigDungeons.ts
+++ b/src/commands/config/ConfigDungeons.ts
@@ -656,7 +656,7 @@ export class ConfigDungeons extends BaseCommand {
             .setCustomId("points_enter")
             .setStyle("PRIMARY");
         const mentionRolesButton = new MessageButton()
-            .setLabel("Roles to mention")
+            .setLabel("Roles to Mention")
             .setCustomId("mention_roles")
             .setStyle("PRIMARY");
         const nitroLimitButton = new MessageButton()
@@ -1232,6 +1232,7 @@ export class ConfigDungeons extends BaseCommand {
                     break;
                 }
                 case "mention_roles": {
+                    if (!cDungeon.mentionRoles) cDungeon.mentionRoles = [];
                     const mentionRoles = await this.configSetting<Role>(
                         ctx,
                         botMsg,

--- a/src/definitions/DungeonRaidInterfaces.ts
+++ b/src/definitions/DungeonRaidInterfaces.ts
@@ -98,13 +98,18 @@ export interface IDungeonOverrideInfo {
      * @type {string[]}
      */
     allowedModifiers: string[];
-    
+
     /**
      * Whether or not location is required to progress the afk check.
      * 
      * @type {boolean}
      */
     locationToProgress?: boolean;
+
+    /**
+     * A list of roles to ping when a raid starts. These are stored as snowflakes in an array.
+     */
+    mentionRoles: string[];
 }
 
 /**
@@ -317,6 +322,11 @@ export interface ICustomDungeonInfo extends IDungeonInfo {
      * @type {string | null}
      */
     logFor: string | null;
+
+    /**
+     * A list of roles to ping when a raid starts. These are stored as snowflakes in an array.
+     */
+    mentionRoles: string[];
 }
 
 /**
@@ -523,7 +533,7 @@ export interface IAfkCheckProperties {
      * @type {boolean}
      */
     createLogChannel: boolean;
-    
+
     /**
      * Default position for the voice channel to avoid confusing staff.
      * 

--- a/src/definitions/DungeonRaidInterfaces.ts
+++ b/src/definitions/DungeonRaidInterfaces.ts
@@ -2,13 +2,13 @@ import { IBasicOverwriteData, IPermAllowDeny, IPropertyKeyValuePair } from "./Mi
 import { OverwriteData, VoiceChannel } from "discord.js";
 
 export type DungeonType = "Uncategorized"
-    | "Basic Dungeons"
-    | "Godland Dungeons"
-    | "Exaltation Dungeons"
-    | "Event Dungeons"
-    | "Mini Dungeons"
-    | "Heroic Dungeons"
-    | "Epic Dungeons";
+| "Basic Dungeons"
+| "Godland Dungeons"
+| "Exaltation Dungeons"
+| "Event Dungeons"
+| "Mini Dungeons"
+| "Heroic Dungeons"
+| "Epic Dungeons";
 
 export type ImageInfo = {
     url: string;

--- a/src/definitions/DungeonRaidInterfaces.ts
+++ b/src/definitions/DungeonRaidInterfaces.ts
@@ -108,6 +108,8 @@ export interface IDungeonOverrideInfo {
 
     /**
      * A list of roles to ping when a raid starts. These are stored as snowflakes in an array.
+     * 
+     * @type {string[]}
      */
     mentionRoles: string[];
 }

--- a/src/definitions/DungeonRaidInterfaces.ts
+++ b/src/definitions/DungeonRaidInterfaces.ts
@@ -2,13 +2,13 @@ import { IBasicOverwriteData, IPermAllowDeny, IPropertyKeyValuePair } from "./Mi
 import { OverwriteData, VoiceChannel } from "discord.js";
 
 export type DungeonType = "Uncategorized"
-| "Basic Dungeons"
-| "Godland Dungeons"
-| "Exaltation Dungeons"
-| "Event Dungeons"
-| "Mini Dungeons"
-| "Heroic Dungeons"
-| "Epic Dungeons";
+    | "Basic Dungeons"
+    | "Godland Dungeons"
+    | "Exaltation Dungeons"
+    | "Event Dungeons"
+    | "Mini Dungeons"
+    | "Heroic Dungeons"
+    | "Epic Dungeons";
 
 export type ImageInfo = {
     url: string;
@@ -108,8 +108,6 @@ export interface IDungeonOverrideInfo {
 
     /**
      * A list of roles to ping when a raid starts. These are stored as snowflakes in an array.
-     * 
-     * @type {string[]}
      */
     mentionRoles: string[];
 }

--- a/src/definitions/MongoDocumentInterfaces.ts
+++ b/src/definitions/MongoDocumentInterfaces.ts
@@ -230,6 +230,13 @@ export interface IGuildInfo {
          * @type {string}
          */
         storageChannelId: string;
+
+        /**
+         * A channel where users can assign themselves roles to be pinged when a headcount or AFK-check begins.
+         * 
+         * @type {string}
+         */
+        rolePingChannelId: string;
     };
 
     /**
@@ -376,6 +383,14 @@ export interface IGuildInfo {
          * @type {IPropertyKeyValuePair<string, number>[]}
          */
         reactionPoints: IPropertyKeyValuePair<string, number>[];
+
+        /**
+         * The stored message of the assign role-pings channel. This is saved so updating the roles obtainable
+         * is not messy. If this is not set, a new message will be sent and this will be overwritten.
+         * 
+         * @type {string}
+         */
+        rolePingMessageId: string;
     };
 
     /**

--- a/src/events/InteractionEvent.ts
+++ b/src/events/InteractionEvent.ts
@@ -8,7 +8,7 @@ import { RaidInstance } from "../instances/RaidInstance";
 import { IGuildInfo } from "../definitions";
 import { MessageUtilities } from "../utilities/MessageUtilities";
 import { StringUtil } from "../utilities/StringUtilities";
-import { ICommandContext } from "../commands";
+import { ConfigChannels, ICommandContext } from "../commands";
 import { TimeUtilities } from "../utilities/TimeUtilities";
 import { MessageConstants } from "../constants/MessageConstants";
 import { StringBuilder } from "../utilities/StringBuilder";
@@ -224,9 +224,9 @@ export async function onInteractionEvent(interaction: Interaction): Promise<void
     const manualVerifyChannels = guildDoc.manualVerificationEntries
         .find(x => x.manualVerifyMsgId === message.id && x.manualVerifyChannelId === channel.id);
 
-    
-    if (manualVerifyChannels 
-        && message.embeds.length > 0 
+
+    if (manualVerifyChannels
+        && message.embeds.length > 0
         && message.embeds[0].footer?.text === "Manual Verification Request") {
         interaction.deferUpdate().catch(LOGGER.error);
         VerifyManager.acknowledgeManualVerif(manualVerifyChannels, resolvedMember, interaction.customId, message)
@@ -296,6 +296,18 @@ export async function onInteractionEvent(interaction: Interaction): Promise<void
                 await ModmailManager.deleteModmailThread(message, guildDoc);
                 return;
             }
+        }
+    }
+
+    // ================================================================================================ //
+
+    // Handle role pings
+
+    if (interaction.channelId === guildDoc.channels.rolePingChannelId) {
+        // This must be a button in the role ping channel.
+        // Check if it starts with `ping-` and then handle it.
+        if (interaction.customId.startsWith("ping-")) {
+            ConfigChannels.handleRolePingInteraction(interaction, guildDoc);
         }
     }
 }

--- a/src/events/MessageDeleteEvent.ts
+++ b/src/events/MessageDeleteEvent.ts
@@ -2,6 +2,7 @@ import { Message, PartialMessage } from "discord.js";
 import { MongoManager } from "../managers/MongoManager";
 import { HeadcountInstance } from "../instances/HeadcountInstance";
 import { RaidInstance } from "../instances/RaidInstance";
+import { ConfigChannels } from "../commands";
 
 export async function onMessageDeleteEvent(msg: Message | PartialMessage): Promise<void> {
     if (!msg.guild) {
@@ -38,6 +39,12 @@ export async function onMessageDeleteEvent(msg: Message | PartialMessage): Promi
             }
         });
         return;
+    }
+
+    if (msg.id === guildDoc.properties.rolePingMessageId) {
+        if (guildDoc.channels.rolePingChannelId) {
+            ConfigChannels.createNewRolePingMessage(msg.client, guildDoc);
+        }
     }
 
     // ...

--- a/src/managers/MongoManager.ts
+++ b/src/managers/MongoManager.ts
@@ -499,7 +499,8 @@ export namespace MongoManager {
                     verificationChannelId: "",
                     manualVerificationChannelId: ""
                 },
-                loggingChannels: []
+                loggingChannels: [],
+                rolePingChannelId: ""
             },
             guildId: guildId,
             guildSections: [],
@@ -515,7 +516,8 @@ export namespace MongoManager {
                 approvedCustomImages: [],
                 genEarlyLocReactions: [],
                 reactionPoints: [],
-                universalEarlyLocReactions: []
+                universalEarlyLocReactions: [],
+                rolePingMessageId: ""
             },
             roles: {
                 mutedRoleId: "",


### PR DESCRIPTION
- Override a base dungeon and select a role by mentioning it or posting the role ID after clicking the mention roles button
- Start a headcount or afk check, the roles will be automatically mentioned on the first message. This means that the pre-AFK message will mention users

- [x] Headcount pings
- [x] AFK check pings
- [x] Multiple role pings for one dungeon

![](https://cdn.discordapp.com/attachments/995242925464223822/1085363773486944326/image.png)
![image](https://user-images.githubusercontent.com/73502164/225175814-94c7e5cc-7529-4fa4-b66b-748f4807670d.png)
![image](https://user-images.githubusercontent.com/73502164/225175851-05ac1e56-6202-41a8-9d11-1eb4a7fe6cfc.png)
![image](https://user-images.githubusercontent.com/73502164/225175860-9411e66d-482d-483e-9998-4b9c4928d999.png)
![image](https://user-images.githubusercontent.com/73502164/225175865-a10dfff5-a4f0-4485-a1b4-a9f92654cfea.png)

Closes #68 