### PR TITLE
fix: dead feedbacks are deleted on start

### DIFF
--- a/src/events/ReadyEvent.ts
+++ b/src/events/ReadyEvent.ts
@@ -6,7 +6,7 @@ import { RaidInstance } from "../instances/RaidInstance";
 import { HeadcountInstance } from "../instances/HeadcountInstance";
 import { Logger } from "../utilities/Logger";
 import getMongoClient = MongoManager.getMongoClient;
-import { BaseGuildTextChannel, CategoryChannel, GuildTextBasedChannel, TextChannel } from "discord.js";
+import { CategoryChannel, GuildTextBasedChannel, TextChannel } from "discord.js";
 
 const LOGGER: Logger = new Logger(__filename, false);
 

--- a/src/events/ReadyEvent.ts
+++ b/src/events/ReadyEvent.ts
@@ -6,6 +6,7 @@ import { RaidInstance } from "../instances/RaidInstance";
 import { HeadcountInstance } from "../instances/HeadcountInstance";
 import { Logger } from "../utilities/Logger";
 import getMongoClient = MongoManager.getMongoClient;
+import { BaseGuildTextChannel, CategoryChannel, GuildTextBasedChannel, TextChannel } from "discord.js";
 
 const LOGGER: Logger = new Logger(__filename, false);
 
@@ -47,6 +48,7 @@ export async function onReadyEvent(): Promise<void> {
 
     LOGGER.info("Resuming any interrupted instances.");
     const guildDocs = await MongoManager.getGuildCollection().find({}).toArray();
+    const activeRaidIds: string[] = [];
     await Promise.all([
         MuteManager.startChecker(guildDocs),
         SuspensionManager.startChecker(guildDocs),
@@ -59,9 +61,33 @@ export async function onReadyEvent(): Promise<void> {
 
             guildDoc.activeRaids.forEach(async raid => {
                 await RaidInstance.createNewLivingInstance(guildDoc, raid);
+                activeRaidIds.push(raid.raidId);
             });
         })
     ]);
+
+    LOGGER.info("Clearing unused feedback channels");
+    await Promise.all(guildDocs.map(doc => {
+        const fbChannel = Bot.BotInstance.client.channels.cache.get(doc.channels.raids.leaderFeedbackChannelId);
+        const storageChannel = Bot.BotInstance.client.channels.cache.get(doc.channels.storageChannelId);
+        if (fbChannel?.isText()) {
+            // we know it's in a guild, and we always know parent is category type
+            const parent = (fbChannel as GuildTextBasedChannel).parent as CategoryChannel;
+            parent.children.map(channel => {
+                if (!channel.isText()) return;
+                if (channel.id === fbChannel.id) return;
+
+                const topicUuid = (channel as TextChannel).topic?.split(" ")[0];
+                if (topicUuid && !activeRaidIds.includes(topicUuid)) {
+                    if (storageChannel) {
+                        RaidInstance.compileDeadFeedbackHistory(channel as TextChannel, storageChannel as TextChannel);
+                    } else {
+                        channel.delete();
+                    }
+                }
+            });
+        }
+    }));
 
     LOGGER.info(`${botUser.tag} events have started successfully.`);
 }

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -2448,7 +2448,14 @@ export class RaidInstance {
         });
     }
 
-    public static async compileDeadFeedbackHistory(feedbackChannel: TextChannel, storageChannel: TextChannel) {
+    /**
+     * Removes any unused feedback channels that were not deleted during last session.
+     * Feedback is compiled and sent to storage channel, if one is configured.
+     * The channel is then deleted.
+     * @param feedbackChannel The channel to collect feedback from and delete
+     * @param storageChannel The channel to send the collected feedback to
+     */
+    public static async compileDeadFeedbackHistory(feedbackChannel: TextChannel, storageChannel: TextChannel): Promise<void> {
         const [pinnedMsgs, allMsgs] = await Promise.all([
             feedbackChannel.messages.fetchPinned(),
             // Assuming that a lot of people won't submit feedback

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -1344,6 +1344,7 @@ export class RaidInstance {
             });
         }
         if (!feedbackChannel) return;
+        this._thisFeedbackChan = feedbackChannel;
 
         const feedbackMsg = await feedbackChannel.send({
             embeds: [
@@ -1456,7 +1457,7 @@ export class RaidInstance {
 
         await this._thisFeedbackChan.send({
             content:
-                "You have **ten** minutes remaining to submit your feedback. If you can't submit your feedback" +
+                "You have **five** minutes remaining to submit your feedback. If you can't submit your feedback" +
                 " in time, you can still submit your feedback via modmail.",
         });
 
@@ -1513,7 +1514,7 @@ export class RaidInstance {
                 this.compileHistory(this._raidStorageChan, sb.toString()),
                 this._thisFeedbackChan.delete(),
             ]);
-        }, 10 * 60 * 1000);
+        }, 5 * 60 * 1000);
     }
 
     /**
@@ -2445,6 +2446,55 @@ export class RaidInstance {
             ],
             content: `__**Report Generated: ${TimeUtilities.getDiscordTime({ style: TimestampType.FullDateNoDay })}**__`,
         });
+    }
+
+    public static async compileDeadFeedbackHistory(feedbackChannel: TextChannel, storageChannel: TextChannel) {
+        const [pinnedMsgs, allMsgs] = await Promise.all([
+            feedbackChannel.messages.fetchPinned(),
+            // Assuming that a lot of people won't submit feedback
+            feedbackChannel.messages.fetch({ limit: 100 }),
+        ]);
+
+        const sb = new StringBuilder()
+            .append("================= LEADER FEEDBACK INFORMATION =================")
+            .appendLine();
+
+        const botMsg = pinnedMsgs.filter((x) => x.author.bot).first();
+        if (botMsg) {
+            const m = await botMsg.fetch();
+            const [upvotes, noPref, downvotes] = await Promise.all([
+                m.reactions.cache.get(EmojiConstants.LONG_UP_ARROW_EMOJI)?.fetch(),
+                m.reactions.cache.get(EmojiConstants.LONG_SIDEWAYS_ARROW_EMOJI)?.fetch(),
+                m.reactions.cache.get(EmojiConstants.LONG_DOWN_ARROW_EMOJI)?.fetch(),
+            ]);
+
+            if (upvotes) sb.append(`- Upvotes      : ${upvotes.count - 1}`).appendLine();
+            if (noPref) sb.append(`- No Preference: ${noPref.count - 1}`).appendLine();
+            if (downvotes) sb.append(`- Downvotes    : ${downvotes.count - 1}`).appendLine();
+        }
+
+        const otherFeedbackMsgs = allMsgs.filter((x) => !x.author.bot);
+        for (const [, feedbackMsg] of otherFeedbackMsgs) {
+            sb.append(`Feedback by ${feedbackMsg.author.tag} (${feedbackMsg.author.id})`)
+                .appendLine()
+                .append("=== BEGIN ===")
+                .appendLine()
+                .append(feedbackMsg.content)
+                .appendLine()
+                .append("=== END ===")
+                .appendLine(2);
+        }
+
+        const probablyMemberInit = feedbackChannel.name.split(" ")[0];
+
+        await storageChannel.send({
+            files: [
+                new MessageAttachment(Buffer.from(sb.toString(), "utf8"), `deadFeedback_${probablyMemberInit}.txt`),
+            ],
+            content: `__**Dead feedback cleared: ${TimeUtilities.getDiscordTime({ style: TimestampType.FullDateNoDay })}**__`
+        });
+
+        await feedbackChannel.delete();
     }
 
     /**


### PR DESCRIPTION
auto deletes feedbacks without an active raid vc on start only
dropped feedback time to 5 minutes to stop it from happening overall (its probably just a restart/crash in the 10 min time)
relies on the uuid in the feedback channel topic