### PR TITLE
feat(dungeon): add realm clearing, misc, exalt options

### DIFF
--- a/src/commands/logging/LogRun.ts
+++ b/src/commands/logging/LogRun.ts
@@ -66,19 +66,7 @@ export class LogRun extends BaseCommand {
                     desc: "The dungeon to log as a complete/assist/fail.",
                     type: ArgumentType.String,
                     restrictions: {
-                        stringChoices: [
-                            { name: "o3", value: "ORYX_3" },
-                            { name: "shatts", value: "SHATTERS" },
-                            { name: "moonlight", value: "MOONLIGHT_VILLAGE" },
-                            { name: "nest", value: "NEST" },
-                            { name: "fungal", value: "FUNGAL_CAVERN" },
-                            { name: "steamworks", value: "STEAMWORKS" },
-                            { name: "cult", value: "CULTIST_HIDEOUT" },
-                            { name: "void", value: "THE_VOID" },
-                            { name: "lost halls", value: "LOST_HALLS" },
-                            { name: "exalt", value: "EXALT_DUNGEON" },
-                            { name: "misc", value: "MISCELLANEOUS_DUNGEON"}
-                        ]
+                        stringChoices: GeneralConstants.DUNGEON_SHORTCUTS
                     },
                     prettyType: "Dungeon name (one word: o3, shatts, nest)",
                     required: false,

--- a/src/commands/logging/LogRun.ts
+++ b/src/commands/logging/LogRun.ts
@@ -68,10 +68,15 @@ export class LogRun extends BaseCommand {
                         stringChoices: [
                             { name: "o3", value: "ORYX_3" },
                             { name: "shatts", value: "SHATTERS" },
+                            { name: "moonlight", value: "MOONLIGHT_VILLAGE" },
                             { name: "nest", value: "NEST" },
-                            { name: "cult", value: "CULTIST_HIDEOUT" },
                             { name: "fungal", value: "FUNGAL_CAVERN" },
+                            { name: "steamworks", value: "STEAMWORKS" },
+                            { name: "cult", value: "CULTIST_HIDEOUT" },
                             { name: "void", value: "THE_VOID" },
+                            { name: "lost halls", value: "LOST_HALLS" },
+                            { name: "exalt", value: "EXALT_DUNGEON" },
+                            { name: "misc", value: "MISCELLANEOUS_DUNGEON"}
                         ]
                     },
                     prettyType: "Dungeon name (one word: o3, shatts, nest)",

--- a/src/commands/logging/LogRun.ts
+++ b/src/commands/logging/LogRun.ts
@@ -12,6 +12,7 @@ import { QuotaManager } from "../../managers/QuotaManager";
 import { QuotaLogType } from "../../definitions/Types";
 import { ButtonConstants } from "../../constants/ButtonConstants";
 import { DungeonUtilities } from "../../utilities/DungeonUtilities";
+import { GeneralConstants } from "../../constants/GeneralConstants";
 
 export class LogRun extends BaseCommand {
     public constructor() {
@@ -65,19 +66,7 @@ export class LogRun extends BaseCommand {
                     desc: "The dungeon to log as a complete/assist/fail.",
                     type: ArgumentType.String,
                     restrictions: {
-                        stringChoices: [
-                            { name: "o3", value: "ORYX_3" },
-                            { name: "shatts", value: "SHATTERS" },
-                            { name: "moonlight", value: "MOONLIGHT_VILLAGE" },
-                            { name: "nest", value: "NEST" },
-                            { name: "fungal", value: "FUNGAL_CAVERN" },
-                            { name: "steamworks", value: "STEAMWORKS" },
-                            { name: "cult", value: "CULTIST_HIDEOUT" },
-                            { name: "void", value: "THE_VOID" },
-                            { name: "lost halls", value: "LOST_HALLS" },
-                            { name: "exalt", value: "EXALT_DUNGEON" },
-                            { name: "misc", value: "MISCELLANEOUS_DUNGEON"}
-                        ]
+                        stringChoices: GeneralConstants.DUNGEON_SHORTCUTS
                     },
                     prettyType: "Dungeon name (one word: o3, shatts, nest)",
                     required: false,

--- a/src/commands/raid-leaders/StartAfkCheck.ts
+++ b/src/commands/raid-leaders/StartAfkCheck.ts
@@ -37,14 +37,17 @@ export class StartAfkCheck extends BaseCommand {
                     type: ArgumentType.String,
                     restrictions: {
                         stringChoices: [
-                            { name: "steamworks", value: "STEAMWORKS" },
                             { name: "o3", value: "ORYX_3" },
                             { name: "shatts", value: "SHATTERS" },
+                            { name: "moonlight", value: "MOONLIGHT_VILLAGE" },
                             { name: "nest", value: "NEST" },
                             { name: "fungal", value: "FUNGAL_CAVERN" },
+                            { name: "steamworks", value: "STEAMWORKS" },
                             { name: "cult", value: "CULTIST_HIDEOUT" },
                             { name: "void", value: "THE_VOID" },
-                            { name: "lost halls", value: "LOST_HALLS" }
+                            { name: "lost halls", value: "LOST_HALLS" },
+                            { name: "exalt", value: "EXALT_DUNGEON" },
+                            { name: "misc", value: "MISCELLANEOUS_DUNGEON"}
                         ]
                     },
                     prettyType: "Dungeon name (one word: o3, shatts, cult)",

--- a/src/commands/raid-leaders/StartAfkCheck.ts
+++ b/src/commands/raid-leaders/StartAfkCheck.ts
@@ -13,6 +13,7 @@ import {
 import { IRaidOptions } from "../../definitions";
 import { TextChannel, VoiceChannel } from "discord.js";
 import { Logger } from "../../utilities/Logger";
+import { GeneralConstants } from "../../constants/GeneralConstants";
 
 const LOGGER: Logger = new Logger(__filename, false);
 
@@ -36,19 +37,7 @@ export class StartAfkCheck extends BaseCommand {
                     desc: "The dungeon for this raid.",
                     type: ArgumentType.String,
                     restrictions: {
-                        stringChoices: [
-                            { name: "o3", value: "ORYX_3" },
-                            { name: "shatts", value: "SHATTERS" },
-                            { name: "moonlight", value: "MOONLIGHT_VILLAGE" },
-                            { name: "nest", value: "NEST" },
-                            { name: "fungal", value: "FUNGAL_CAVERN" },
-                            { name: "steamworks", value: "STEAMWORKS" },
-                            { name: "cult", value: "CULTIST_HIDEOUT" },
-                            { name: "void", value: "THE_VOID" },
-                            { name: "lost halls", value: "LOST_HALLS" },
-                            { name: "exalt", value: "EXALT_DUNGEON" },
-                            { name: "misc", value: "MISCELLANEOUS_DUNGEON"}
-                        ]
+                        stringChoices: GeneralConstants.DUNGEON_SHORTCUTS
                     },
                     prettyType: "Dungeon name (one word: o3, shatts, cult)",
                     required: false,

--- a/src/commands/raid-leaders/StartAfkCheck.ts
+++ b/src/commands/raid-leaders/StartAfkCheck.ts
@@ -37,19 +37,7 @@ export class StartAfkCheck extends BaseCommand {
                     desc: "The dungeon for this raid.",
                     type: ArgumentType.String,
                     restrictions: {
-                        stringChoices: [
-                            { name: "o3", value: "ORYX_3" },
-                            { name: "shatts", value: "SHATTERS" },
-                            { name: "moonlight", value: "MOONLIGHT_VILLAGE" },
-                            { name: "nest", value: "NEST" },
-                            { name: "fungal", value: "FUNGAL_CAVERN" },
-                            { name: "steamworks", value: "STEAMWORKS" },
-                            { name: "cult", value: "CULTIST_HIDEOUT" },
-                            { name: "void", value: "THE_VOID" },
-                            { name: "lost halls", value: "LOST_HALLS" },
-                            { name: "exalt", value: "EXALT_DUNGEON" },
-                            { name: "misc", value: "MISCELLANEOUS_DUNGEON"}
-                        ]
+                        stringChoices: GeneralConstants.DUNGEON_SHORTCUTS
                     },
                     prettyType: "Dungeon name (one word: o3, shatts, cult)",
                     required: false,

--- a/src/commands/raid-leaders/StartHeadcount.ts
+++ b/src/commands/raid-leaders/StartHeadcount.ts
@@ -29,19 +29,7 @@ export class StartHeadcount extends BaseCommand {
                     desc: "The dungeon for this headcount.",
                     type: ArgumentType.String,
                     restrictions: {
-                        stringChoices: [
-                            { name: "o3", value: "ORYX_3" },
-                            { name: "shatts", value: "SHATTERS" },
-                            { name: "moonlight", value: "MOONLIGHT_VILLAGE" },
-                            { name: "nest", value: "NEST" },
-                            { name: "fungal", value: "FUNGAL_CAVERN" },
-                            { name: "steamworks", value: "STEAMWORKS" },
-                            { name: "cult", value: "CULTIST_HIDEOUT" },
-                            { name: "void", value: "THE_VOID" },
-                            { name: "lost halls", value: "LOST_HALLS" },
-                            { name: "exalt", value: "EXALT_DUNGEON" },
-                            { name: "misc", value: "MISCELLANEOUS_DUNGEON"}
-                        ]
+                        stringChoices: GeneralConstants.DUNGEON_SHORTCUTS
                     },
                     prettyType: "Dungeon name (one word: o3, oryx, shatts, shatters)",
                     required: false,

--- a/src/commands/raid-leaders/StartHeadcount.ts
+++ b/src/commands/raid-leaders/StartHeadcount.ts
@@ -7,6 +7,7 @@ import {
     getSelectedSection
 } from "./common/RaidLeaderCommon";
 import { HeadcountInstance } from "../../instances/HeadcountInstance";
+import { GeneralConstants } from "../../constants/GeneralConstants";
 
 export class StartHeadcount extends BaseCommand {
     public static readonly START_HC_CMD_CODE: string = "HEADCOUNT_START";
@@ -28,19 +29,7 @@ export class StartHeadcount extends BaseCommand {
                     desc: "The dungeon for this headcount.",
                     type: ArgumentType.String,
                     restrictions: {
-                        stringChoices: [
-                            { name: "o3", value: "ORYX_3" },
-                            { name: "shatts", value: "SHATTERS" },
-                            { name: "moonlight", value: "MOONLIGHT_VILLAGE" },
-                            { name: "nest", value: "NEST" },
-                            { name: "fungal", value: "FUNGAL_CAVERN" },
-                            { name: "steamworks", value: "STEAMWORKS" },
-                            { name: "cult", value: "CULTIST_HIDEOUT" },
-                            { name: "void", value: "THE_VOID" },
-                            { name: "lost halls", value: "LOST_HALLS" },
-                            { name: "exalt", value: "EXALT_DUNGEON" },
-                            { name: "misc", value: "MISCELLANEOUS_DUNGEON"}
-                        ]
+                        stringChoices: GeneralConstants.DUNGEON_SHORTCUTS
                     },
                     prettyType: "Dungeon name (one word: o3, oryx, shatts, shatters)",
                     required: false,

--- a/src/commands/raid-leaders/StartHeadcount.ts
+++ b/src/commands/raid-leaders/StartHeadcount.ts
@@ -29,14 +29,17 @@ export class StartHeadcount extends BaseCommand {
                     type: ArgumentType.String,
                     restrictions: {
                         stringChoices: [
-                            { name: "steamworks", value: "STEAMWORKS" },
                             { name: "o3", value: "ORYX_3" },
                             { name: "shatts", value: "SHATTERS" },
+                            { name: "moonlight", value: "MOONLIGHT_VILLAGE" },
                             { name: "nest", value: "NEST" },
                             { name: "fungal", value: "FUNGAL_CAVERN" },
+                            { name: "steamworks", value: "STEAMWORKS" },
                             { name: "cult", value: "CULTIST_HIDEOUT" },
                             { name: "void", value: "THE_VOID" },
-                            { name: "lost halls", value: "LOST_HALLS" }
+                            { name: "lost halls", value: "LOST_HALLS" },
+                            { name: "exalt", value: "EXALT_DUNGEON" },
+                            { name: "misc", value: "MISCELLANEOUS_DUNGEON"}
                         ]
                     },
                     prettyType: "Dungeon name (one word: o3, oryx, shatts, shatters)",

--- a/src/constants/EmojiConstants.ts
+++ b/src/constants/EmojiConstants.ts
@@ -113,6 +113,7 @@ export namespace EmojiConstants {
     export const ARMOR_BREAK: string = "678792068889444397";
     export const CURSE: string = "929850982374989905";
     export const EXPOSE: string = "963536541567840346";
+    export const SPEEDY: string = "1111082594877063198";
 
     // util/generic
     export const RUSHING_CLASS: string = "585616161878835220";

--- a/src/constants/GeneralConstants.ts
+++ b/src/constants/GeneralConstants.ts
@@ -1,3 +1,4 @@
+import { DungeonShortcuts } from "../definitions/Types";
 export namespace GeneralConstants {
     export const ZERO_WIDTH_SPACE: string = "\u200b";
 
@@ -5,6 +6,20 @@ export namespace GeneralConstants {
         ..."ABCDEFGHIJKLMNOPQRSTUVWXYZ".split(""),
         ..."abcdefghijklmnopqrstuvwxyz".split(""),
         ..."0123456789".split("")
+    ];
+
+    export const DUNGEON_SHORTCUTS: DungeonShortcuts[] = [
+        { name: "o3", value: "ORYX_3" },
+        { name: "shatts", value: "SHATTERS" },
+        { name: "moonlight", value: "MOONLIGHT_VILLAGE" },
+        { name: "nest", value: "NEST" },
+        { name: "fungal", value: "FUNGAL_CAVERN" },
+        { name: "steamworks", value: "STEAMWORKS" },
+        { name: "cult", value: "CULTIST_HIDEOUT" },
+        { name: "void", value: "THE_VOID" },
+        { name: "lost halls", value: "LOST_HALLS" },
+        { name: "exalt", value: "EXALT_DUNGEON" },
+        { name: "misc", value: "MISCELLANEOUS_DUNGEON"}
     ];
 
     export const GITHUB_URL: string = "https://github.com/ewang2002/ToogaBooga";

--- a/src/constants/GeneralConstants.ts
+++ b/src/constants/GeneralConstants.ts
@@ -19,7 +19,7 @@ export namespace GeneralConstants {
         { name: "void", value: "THE_VOID" },
         { name: "lost halls", value: "LOST_HALLS" },
         { name: "exalt", value: "EXALT_DUNGEON" },
-        { name: "misc", value: "MISCELLANEOUS_DUNGEON"}
+        { name: "misc", value: "MISCELLANEOUS_DUNGEON" }
     ];
 
     export const GITHUB_URL: string = "https://github.com/ewang2002/ToogaBooga";

--- a/src/constants/dungeons/DungeonData.ts
+++ b/src/constants/dungeons/DungeonData.ts
@@ -1883,7 +1883,7 @@ export const DUNGEON_DATA: readonly IDungeonInfo[] = [
             {
                 mapKey: "MYSTIC",
                 maxEarlyLocation: 0
-            },
+            }
         ],
         portalLink: {
             url: "https://i.imgur.com/CLzxdEM.png",
@@ -1953,6 +1953,121 @@ export const DUNGEON_DATA: readonly IDungeonInfo[] = [
             0x1dbfaa
         ],
         dungeonCategory: "Basic Dungeons",
+        isBuiltIn: true
+    },
+    {
+        codeName: "REALM_CLEARING",
+        dungeonName: "Realm Clearing",
+        portalEmojiId: "1111077858803200144",
+        keyReactions: [
+            {
+                mapKey: "SHIELD_RUNE",
+                maxEarlyLocation: 2
+            },
+            {
+                mapKey: "SWORD_RUNE",
+                maxEarlyLocation: 2
+            },
+            {
+                mapKey: "HELM_RUNE",
+                maxEarlyLocation: 2
+            }
+        ],
+        otherReactions: [
+            {
+                mapKey: "TRICKSTER",
+                maxEarlyLocation: 3
+            },
+            {
+                mapKey: "SPEEDY",
+                maxEarlyLocation: 3
+            }
+        ],
+        portalLink: {
+            url: "https://i.imgur.com/oR1wqQ3.png",
+            name: "Realm Portal"
+        },
+        bossLinks: [
+            {
+                url: "https://i.imgur.com/HGmFZAA.png",
+                name: "Skull Shrine"
+            },
+            {
+                url: "https://i.imgur.com/NERHSHK.png",
+                name: "Hermit God"
+            },
+            {
+                url: "https://i.imgur.com/TLZfnSb.png",
+                name: "Cube God"
+            }
+        ],
+        dungeonColors: [
+            0x1dbfaa
+        ],
+        dungeonCategory: "Basic Dungeons",
+        isBuiltIn: true
+    },
+    {
+        codeName: "EXALT_DUNGEON",
+        dungeonName: "Exalt Dungeon",
+        portalEmojiId: "1110284783541559347",
+        keyReactions: [
+            {
+                mapKey: "SHIELD_RUNE",
+                maxEarlyLocation: 2
+            },
+            {
+                mapKey: "SWORD_RUNE",
+                maxEarlyLocation: 2
+            },
+            {
+                mapKey: "HELM_RUNE",
+                maxEarlyLocation: 2
+            },
+            {
+                mapKey: "CULT_KEY",
+                maxEarlyLocation: 2
+            },
+            {
+                mapKey: "VOID_KEY",
+                maxEarlyLocation: 2
+            },
+            {
+                mapKey: "SHATTERS_KEY",
+                maxEarlyLocation: 2
+            },
+            {
+                mapKey: "MOONLIGHT_VILLAGE_KEY",
+                maxEarlyLocation: 2
+            },
+            {
+                mapKey: "STEAMWORKS_KEY",
+                maxEarlyLocation: 2
+            },
+            {
+                mapKey: "FUNGAL_CAVERN_KEY",
+                maxEarlyLocation: 2
+            },
+            {
+                mapKey: "NEST_KEY",
+                maxEarlyLocation: 2
+            }
+        ],
+        otherReactions: [],
+        portalLink: {
+            url: "https://i.imgur.com/8eDjmCe.png",
+            name: "Oryx the Mad Beachcake"
+        },
+        bossLinks: [
+            {
+                url: "https://i.imgur.com/8eDjmCe.png",
+                name: "Oryx the Mad Beachcake"
+            }
+        ],
+        dungeonColors: [
+            0x1dbfaa
+        ],
+        dungeonCategory: "Exaltation Dungeons",
         isBuiltIn: true
     },
     {

--- a/src/constants/dungeons/MappedAfkCheckReactions.ts
+++ b/src/constants/dungeons/MappedAfkCheckReactions.ts
@@ -239,6 +239,15 @@ export const MAPPED_AFK_CHECK_REACTIONS: IMappedAfkCheckReactions = {
         name: "Armor Break",
         isExaltKey: false
     },
+    SPEEDY: {
+        type: "STATUS_EFFECT",
+        emojiInfo: {
+            isCustom: true,
+            identifier: EmojiConstants.SPEEDY
+        },
+        name: "Speedy",
+        isExaltKey: false
+    },
     Expose: {
         type: "STATUS_EFFECT",
         emojiInfo: {

--- a/src/definitions/Types.ts
+++ b/src/definitions/Types.ts
@@ -13,6 +13,11 @@ export type TimedResult<R> = {
     value: R | null;
 };
 
+export type DungeonShortcuts = {
+    name: string;
+    value: string;
+};
+
 export type QuotaLogType = QuotaRunLogType
 | "Parse"
 | "ManualVerify"


### PR DESCRIPTION
- Added Realm Clearing and Exalt Dungeon as options for headcount/afkcheck

- Added the Speedy reaction emoji (for realm clearing HC)

- Updated the "dungeon" option shortcut for the logrun, headcount and afkcheck commands. Now includes ALL exalt dungeons and 'Misc' for miscellaneous dungeons.