### PR TITLE
Advanced Nest icon

### DIFF
--- a/src/constants/dungeons/DungeonData.ts
+++ b/src/constants/dungeons/DungeonData.ts
@@ -1358,20 +1358,7 @@ export const DUNGEON_DATA: readonly IDungeonInfo[] = [
             url: "https://i.imgur.com/8WyDft8.png",
             name: "Advanced Steamworks Portal"
         },
-        bossLinks: [
-            {
-                url: "https://i.imgur.com/mK2gN3p.png",
-                name: "Core Form"
-            },
-            {
-                url: "https://i.imgur.com/Bvc5thY.png",
-                name: "Enforcer Form"
-            },
-            {
-                url: "https://i.imgur.com/a6SxEBx.png",
-                name: "Dragon Form"
-            }
-        ],
+        bossLinks: [],
         dungeonColors: [
             0xC0C0C0,
             0x808080,
@@ -1590,13 +1577,9 @@ export const DUNGEON_DATA: readonly IDungeonInfo[] = [
         },
         bossLinks: [
             {
-                url: "https://i.imgur.com/hUWc3IV.png",
-                name: "Killer Queen Bee"
+                url: "https://i.imgur.com/PKYrWvX.png",
+                name: "Green Beehemoth"
             },
-            {
-                url: "https://i.imgur.com/Hn5Ugix.png",
-                name: "The Beekeeper"
-            }
         ],
         dungeonColors: [
             0xed9121,

--- a/src/constants/dungeons/DungeonData.ts
+++ b/src/constants/dungeons/DungeonData.ts
@@ -1281,7 +1281,7 @@ export const DUNGEON_DATA: readonly IDungeonInfo[] = [
             }
         ],
         portalLink: {
-            url: "https://i.imgur.com/8WyDft8.png",
+            url: "https://i.imgur.com/ItKUC5A.png",
             name: "Steamworks Portal"
         },
         bossLinks: [

--- a/src/constants/dungeons/DungeonData.ts
+++ b/src/constants/dungeons/DungeonData.ts
@@ -1281,8 +1281,82 @@ export const DUNGEON_DATA: readonly IDungeonInfo[] = [
             }
         ],
         portalLink: {
-            url: "https://i.imgur.com/ItKUC5A.png",
+            url: "https://i.imgur.com/8WyDft8.png",
             name: "Steamworks Portal"
+        },
+        bossLinks: [
+            {
+                url: "https://i.imgur.com/mK2gN3p.png",
+                name: "Core Form"
+            },
+            {
+                url: "https://i.imgur.com/Bvc5thY.png",
+                name: "Enforcer Form"
+            },
+            {
+                url: "https://i.imgur.com/a6SxEBx.png",
+                name: "Dragon Form"
+            }
+        ],
+        dungeonColors: [
+            0xC0C0C0,
+            0x808080,
+            0xFF00FF
+        ],
+        dungeonCategory: "Exaltation Dungeons",
+        isBuiltIn: true
+    },
+    {
+        codeName: "ADVANCED STEAMWORKS",
+        dungeonName: "Advanced Steamworks",
+        portalEmojiId: "1158160675105935440",
+        keyReactions: [
+            {
+                mapKey: "ADVANCED_STEAMWORKS_KEY",
+                maxEarlyLocation: 2
+            }
+        ],
+        otherReactions: [
+            {
+                mapKey: "CURSE",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "MSEAL",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "ARMOR_BREAK",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "FUNGAL_TOME",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "WARRIOR",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "KNIGHT",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "PALADIN",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "TRICKSTER",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "MYSTIC",
+                maxEarlyLocation: 0
+            }
+        ],
+        portalLink: {
+            url: "https://i.imgur.com/8WyDft8.png",
+            name: "Advanced Steamworks Portal"
         },
         bossLinks: [
             {
@@ -1442,6 +1516,77 @@ export const DUNGEON_DATA: readonly IDungeonInfo[] = [
         portalLink: {
             url: "https://i.imgur.com/WQ95Y0j.png",
             name: "Nest Portal"
+        },
+        bossLinks: [
+            {
+                url: "https://i.imgur.com/hUWc3IV.png",
+                name: "Killer Queen Bee"
+            },
+            {
+                url: "https://i.imgur.com/Hn5Ugix.png",
+                name: "The Beekeeper"
+            }
+        ],
+        dungeonColors: [
+            0xed9121,
+            0x18c7db,
+            0xe3e019,
+            0xbd0d30
+        ],
+        dungeonCategory: "Exaltation Dungeons",
+        isBuiltIn: true
+    },
+    {
+        codeName: "ADVANCED_NEST",
+        dungeonName: "Advanced Nest",
+        portalEmojiId: "1158159293657399356",
+        keyReactions: [
+            {
+                mapKey: "ADVANCED_NEST_KEY",
+                maxEarlyLocation: 3
+            }
+        ],
+        otherReactions: [
+            {
+                mapKey: "QUIVER_THUNDER",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "ARMOR_BREAK",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "FUNGAL_TOME",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "WARRIOR",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "KNIGHT",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "PALADIN",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "PRIEST",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "MYSTIC",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "SLOW",
+                maxEarlyLocation: 0
+            }
+        ],
+        portalLink: {
+            url: "https://i.imgur.com/oieOJGo.png",
+            name: "Advanced Nest Portal"
         },
         bossLinks: [
             {

--- a/src/constants/dungeons/DungeonData.ts
+++ b/src/constants/dungeons/DungeonData.ts
@@ -1358,7 +1358,20 @@ export const DUNGEON_DATA: readonly IDungeonInfo[] = [
             url: "https://i.imgur.com/8WyDft8.png",
             name: "Advanced Steamworks Portal"
         },
-        bossLinks: [],
+        bossLinks: [
+            {
+                url: "https://i.imgur.com/mK2gN3p.png",
+                name: "Core Form"
+            },
+            {
+                url: "https://i.imgur.com/Bvc5thY.png",
+                name: "Enforcer Form"
+            },
+            {
+                url: "https://i.imgur.com/a6SxEBx.png",
+                name: "Dragon Form"
+            }
+        ],
         dungeonColors: [
             0xC0C0C0,
             0x808080,

--- a/src/constants/dungeons/MappedAfkCheckReactions.ts
+++ b/src/constants/dungeons/MappedAfkCheckReactions.ts
@@ -667,6 +667,15 @@ export const MAPPED_AFK_CHECK_REACTIONS: IMappedAfkCheckReactions = {
         name: "Steamworks Key",
         isExaltKey: true
     },
+    ADVANCED_STEAMWORKS_KEY: {
+        type: "KEY",
+        emojiInfo: {
+            isCustom: true,
+            identifier: "1158160722535129159"
+        },
+        name: "Advanced Steamworks Key",
+        isExaltKey: true
+    },
     SHATTERS_KEY: {
         type: "KEY",
         emojiInfo: {
@@ -692,6 +701,15 @@ export const MAPPED_AFK_CHECK_REACTIONS: IMappedAfkCheckReactions = {
             identifier: "585617056192266240"
         },
         name: "Nest Key",
+        isExaltKey: true
+    },
+    ADVANCED_NEST_KEY: {
+        type: "KEY",
+        emojiInfo: {
+            isCustom: true,
+            identifier: "1158159649619595384"
+        },
+        name: "Advanced Nest Key",
         isExaltKey: true
     },
     CURSED_LIBRARY_KEY: {


### PR DESCRIPTION
Made it so that the HC/AFK for advanced nest will only show the green bee, which is specific to advanced nest. This is to help show the raiders that it is advanced and not a normal nest, although the name is also already different. 

Sorry for the extra PR, i wanted to add this to the first one, but realmeye didnt have the picture of green bee, so I assumed no one did, but apparently its in a deca blog.