### PR TITLE
add Spectral Penitentiary

### DIFF
--- a/src/commands/logging/LogKey.ts
+++ b/src/commands/logging/LogKey.ts
@@ -56,6 +56,7 @@ export class LogKey extends BaseCommand {
                             { name: "fungal", value: "FUNGAL_CAVERN_KEY" },
                             { name: "steamworks", value: "STEAMWORKS_KEY" },
                             { name: "vial", value: "VIAL_OF_PURE_DARKNESS" },
+                            { name: "spectral", value: "SPECTRAL_KEY" },
                         ]
                     },
                     prettyType: "Key name (one word: shield, shatts, fungal)",

--- a/src/constants/GeneralConstants.ts
+++ b/src/constants/GeneralConstants.ts
@@ -15,6 +15,7 @@ export namespace GeneralConstants {
         { name: "nest", value: "NEST" },
         { name: "fungal", value: "FUNGAL_CAVERN" },
         { name: "steamworks", value: "STEAMWORKS" },
+        { name: "spectral", value: "SPECTRAL_PENITENTIARY" },
         { name: "cult", value: "CULTIST_HIDEOUT" },
         { name: "void", value: "THE_VOID" },
         { name: "lost halls", value: "LOST_HALLS" },

--- a/src/constants/dungeons/DungeonData.ts
+++ b/src/constants/dungeons/DungeonData.ts
@@ -2070,6 +2070,81 @@ export const DUNGEON_DATA: readonly IDungeonInfo[] = [
         isBuiltIn: true
     },
     {
+        codeName: "SPECTRAL_PENITENTIARY",
+        dungeonName: "Spectral Penitentiary",
+        portalEmojiId: "1290096126850105426",
+        keyReactions: [
+            {
+                mapKey: "SPECTRAL_KEY",
+                maxEarlyLocation: 2
+            }
+        ],
+        otherReactions: [
+            {
+                mapKey: "QUIVER_THUNDER",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "SLOW",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "CURSE",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "MSEAL",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "ARMOR_BREAK",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "FUNGAL_TOME",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "WARRIOR",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "KNIGHT",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "PALADIN",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "TRICKSTER",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "MYSTIC",
+                maxEarlyLocation: 0
+            }
+        ],
+        portalLink: {
+            url: "https://i.imgur.com/RVWq9ua.png",
+            name: "Spectral Penitentiary Portal"
+        },
+        bossLinks: [
+            {
+                url: "https://i.imgur.com/jrcY9jC.png",
+                name: "Soulwarden Murcian"
+            }
+        ],
+        dungeonColors: [
+            0x001e28,
+            0x58dd85,
+            0x30b2aa,
+            0x124a69
+        ],
+        dungeonCategory: "Exaltation Dungeons",
+        isBuiltIn: true
+    },
+    {
         codeName: "MISCELLANEOUS_DUNGEON",
         dungeonName: "Miscellaneous Dungeon",
         portalEmojiId: "574080648000569353",
@@ -2191,6 +2266,10 @@ export const DUNGEON_DATA: readonly IDungeonInfo[] = [
             },
             {
                 mapKey: "NEST_KEY",
+                maxEarlyLocation: 2
+            },
+            {
+                mapKey: "SPECTRAL_KEY",
                 maxEarlyLocation: 2
             }
         ],

--- a/src/constants/dungeons/MappedAfkCheckReactions.ts
+++ b/src/constants/dungeons/MappedAfkCheckReactions.ts
@@ -766,6 +766,15 @@ export const MAPPED_AFK_CHECK_REACTIONS: IMappedAfkCheckReactions = {
         name: "Fungal Cavern Key",
         isExaltKey: true
     },
+    SPECTRAL_KEY: {
+        type: "KEY",
+        emojiInfo: {
+            isCustom: true,
+            identifier: "1290096084395495454"
+        },
+        name: "Spectral Penitentiary Key",
+        isExaltKey: true
+    },
     MISCELLANEOUS_DUNGEON_KEY: {
         type: "KEY",
         emojiInfo: {

--- a/src/managers/LoggerManager.ts
+++ b/src/managers/LoggerManager.ts
@@ -20,7 +20,9 @@ export namespace LoggerManager {
         "LOST_HALLS_KEY",
         "NEST_KEY",
         "SHATTERS_KEY",
-        "FUNGAL_CAVERN_KEY"
+        "FUNGAL_CAVERN_KEY",
+        "STEAMWORKS_KEY",
+        "SPECTRAL_KEY"
     ];
 
     export type DungeonLedType = Collection<string, { completed: number; failed: number; assisted: number; }>;


### PR DESCRIPTION
- Added Spectral Penitentiary to DungeonData as exalt dungeon
- Added Spectral Penitentiary to DungeonData as a react for Exalt Dungeon headcount
- Added Spectral Penitentiary to DUNGEON_SHORTCUTS
- Added Spectral Penitentiary to LogKey ("SPECTRAL_KEY")
- Added Spectral Penitentiary to LoggerManager
- Added Spectral Penitentiary to MappedAfkCheckReactions