### PR TITLE
custom dungeon vc limit overrides default section vc limit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,6 @@ import { DUNGEON_DATA } from "./constants/dungeons/DungeonData";
 import { MAPPED_AFK_CHECK_REACTIONS } from "./constants/dungeons/MappedAfkCheckReactions";
 
 (async () => {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-
     const allEmojis = DUNGEON_DATA.flatMap(x => x.keyReactions.concat(x.otherReactions));
     for (const { mapKey } of allEmojis) {
         if (mapKey in MAPPED_AFK_CHECK_REACTIONS) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import { DUNGEON_DATA } from "./constants/dungeons/DungeonData";
 import { MAPPED_AFK_CHECK_REACTIONS } from "./constants/dungeons/MappedAfkCheckReactions";
 
 (async () => {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
     const allEmojis = DUNGEON_DATA.flatMap(x => x.keyReactions.concat(x.otherReactions));
     for (const { mapKey } of allEmojis) {
         if (mapKey in MAPPED_AFK_CHECK_REACTIONS) {

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -431,6 +431,13 @@ export class RaidInstance {
         } else {
             // If this is not a base or derived dungeon (i.e. it's a custom dungeon), then it must specify the nitro
             // limit.
+
+            // respect a custom dungeon’s own VC cap if set
+            const custom = dungeon as ICustomDungeonInfo;
+
+            const vc = custom.vcLimit ?? -1;
+            if (vc !== -1) raidLimit = vc;
+
             numEarlyLoc = (dungeon as ICustomDungeonInfo).nitroEarlyLocationLimit;
             if (numEarlyLoc === -1) {
                 numEarlyLoc = section.otherMajorConfig.afkCheckProperties.nitroEarlyLocationLimit;


### PR DESCRIPTION
Custom Dungeons with a set vc limit were not correctly overriding the default sections vc limit. Base dungeons with set vc limits already does override the section vc limit as intended.