### PR TITLE
add Ice Citadel

### DIFF
--- a/src/commands/logging/LogKey.ts
+++ b/src/commands/logging/LogKey.ts
@@ -57,6 +57,7 @@ export class LogKey extends BaseCommand {
                             { name: "steamworks", value: "STEAMWORKS_KEY" },
                             { name: "vial", value: "VIAL_OF_PURE_DARKNESS" },
                             { name: "spectral", value: "SPECTRAL_KEY" },
+                            { name: "citadel", value: "CITADEL_KEY" },
                         ]
                     },
                     prettyType: "Key name (one word: shield, shatts, fungal)",

--- a/src/constants/GeneralConstants.ts
+++ b/src/constants/GeneralConstants.ts
@@ -16,6 +16,7 @@ export namespace GeneralConstants {
         { name: "fungal", value: "FUNGAL_CAVERN" },
         { name: "steamworks", value: "STEAMWORKS" },
         { name: "spectral", value: "SPECTRAL_PENITENTIARY" },
+        { name: "citadel", value: "ICE_CITADEL" },
         { name: "cult", value: "CULTIST_HIDEOUT" },
         { name: "void", value: "THE_VOID" },
         { name: "lost halls", value: "LOST_HALLS" },

--- a/src/constants/dungeons/DungeonData.ts
+++ b/src/constants/dungeons/DungeonData.ts
@@ -2145,6 +2145,81 @@ export const DUNGEON_DATA: readonly IDungeonInfo[] = [
         isBuiltIn: true
     },
     {
+        codeName: "ICE_CITADEL",
+        dungeonName: "Ice Citadel",
+        portalEmojiId: "1394830571431137362",
+        keyReactions: [
+            {
+                mapKey: "CITADEL_KEY",
+                maxEarlyLocation: 2
+            }
+        ],
+        otherReactions: [
+            {
+                mapKey: "QUIVER_THUNDER",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "SLOW",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "CURSE",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "MSEAL",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "ARMOR_BREAK",
+                maxEarlyLocation: 1
+            },
+            {
+                mapKey: "FUNGAL_TOME",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "WARRIOR",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "KNIGHT",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "PALADIN",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "TRICKSTER",
+                maxEarlyLocation: 0
+            },
+            {
+                mapKey: "MYSTIC",
+                maxEarlyLocation: 0
+            }
+        ],
+        portalLink: {
+            url: "https://i.imgur.com/Ma5cQyB.png",
+            name: "Ice Citadel Portal"
+        },
+        bossLinks: [
+            {
+                url: "https://i.imgur.com/cbOogNc.png",
+                name: "Esben the Neurotic"
+            }
+        ],
+        dungeonColors: [
+            0x1b5a74,
+            0xb7e1f6,
+            0xbab294,
+            0xffffff
+        ],
+        dungeonCategory: "Exaltation Dungeons",
+        isBuiltIn: true
+    },
+    {
         codeName: "MISCELLANEOUS_DUNGEON",
         dungeonName: "Miscellaneous Dungeon",
         portalEmojiId: "574080648000569353",
@@ -2279,7 +2354,12 @@ export const DUNGEON_DATA: readonly IDungeonInfo[] = [
             {
                 mapKey: "SPECTRAL_KEY",
                 maxEarlyLocation: 2
+            },
+            {
+                mapKey: "CITADEL_KEY",
+                maxEarlyLocation: 2
             }
+
         ],
         otherReactions: [],
         portalLink: {

--- a/src/constants/dungeons/MappedAfkCheckReactions.ts
+++ b/src/constants/dungeons/MappedAfkCheckReactions.ts
@@ -775,6 +775,15 @@ export const MAPPED_AFK_CHECK_REACTIONS: IMappedAfkCheckReactions = {
         name: "Spectral Penitentiary Key",
         isExaltKey: true
     },
+    CITADEL_KEY: {
+        type: "KEY",
+        emojiInfo: {
+            isCustom: true,
+            identifier: "1394830554515374193"
+        },
+        name: "Ice Citadel Key",
+        isExaltKey: true
+    },
     MISCELLANEOUS_DUNGEON_KEY: {
         type: "KEY",
         emojiInfo: {

--- a/src/managers/LoggerManager.ts
+++ b/src/managers/LoggerManager.ts
@@ -22,7 +22,8 @@ export namespace LoggerManager {
         "SHATTERS_KEY",
         "FUNGAL_CAVERN_KEY",
         "STEAMWORKS_KEY",
-        "SPECTRAL_KEY"
+        "SPECTRAL_KEY",
+        "CITADEL_KEY"
     ];
 
     export type DungeonLedType = Collection<string, { completed: number; failed: number; assisted: number; }>;


### PR DESCRIPTION
- Added Ice Citadel to DungeonData as exalt dungeon
- Added Ice Citadel to DungeonData as a react for Exalt Dungeon headcount
- Added Ice Citadel to DUNGEON_SHORTCUTS
- Added Ice Citadel to LogKey ("CITADEL_KEY")
- Added Ice Citadel to LoggerManager
- Added Ice Citadel to MappedAfkCheckReactions

Similar to #294 