### PR TITLE
Added "Never" option to quota auto reset (manual only) | Can Now Set End Time (visual only)

### DIFF
--- a/src/commands/config/ConfigQuotas.ts
+++ b/src/commands/config/ConfigQuotas.ts
@@ -20,6 +20,7 @@ import { MongoManager } from "../../managers/MongoManager";
 import { QuotaLogType, QuotaRunLogType, TimedResult, TimedStatus } from "../../definitions/Types";
 import { ArrayUtilities } from "../../utilities/ArrayUtilities";
 import { DungeonUtilities } from "../../utilities/DungeonUtilities";
+import { TimeUtilities, TimestampType } from "../../utilities/TimeUtilities";
 import { GeneralConstants } from "../../constants/GeneralConstants";
 import { GlobalFgrUtilities } from "../../utilities/fetch-get-request/GlobalFgrUtilities";
 import { QuotaManager } from "../../managers/QuotaManager";
@@ -158,7 +159,7 @@ export class ConfigQuotas extends BaseCommand {
                 "Click on the `Set Panel End Date` button to set a **display-only** end date shown on all quota panels when using manual resets."
                 + " This does **not** automatically reset quotas."
                 + (panelEndTime
-                    ? `\nCurrent panel end date: <t:${Math.floor(panelEndTime / 1000)}:F>`
+                    ? `\nCurrent panel end date: ${TimeUtilities.getDiscordTime({ time: panelEndTime, style: TimestampType.FullDateNoDay })}`
                     : `\nCurrent panel end date: ${StringUtil.codifyString("Not Set")}`)
             );
 
@@ -422,8 +423,10 @@ export class ConfigQuotas extends BaseCommand {
                                         .append(" It does **not** automatically reset quotas.")
                                         .appendLine(2)
                                         .append("Send a date/time in one of these formats (UTC/GMT):").appendLine()
-                                        .append("- `YYYY-MM-DD`").appendLine()
-                                        .append("- `YYYY-MM-DD HH:MM` (24-hour)").appendLine(2)
+                                        .append("- `YYYY-MM-DD` (e.g., `2025-11-09`)").appendLine()
+                                        .append("- `YYYY-MM-DD HH:MM` (24-hour, e.g., `2025-11-09 17:30`)").appendLine()
+                                        .append("Note: Use 4 digits for year, 2 digits for month, and 2 digits for day.")
+                                        .appendLine(2)
                                         .append("Type `clear` to remove the panel end date.")
                                         .toString()
                                 )
@@ -493,7 +496,7 @@ export class ConfigQuotas extends BaseCommand {
                         );
 
                         await baseInt.followUp({
-                            content: `✅ Panel end date set to <t:${Math.floor(parsed / 1000)}:F> (UTC).`,
+                            content: `Panel end date set to ${TimeUtilities.getDiscordTime({ time: parsed, style: TimestampType.FullDateNoDay })} (UTC).`,
                             ephemeral: true
                         });
 
@@ -501,7 +504,7 @@ export class ConfigQuotas extends BaseCommand {
                         break;
                     } else {
                         await baseInt.followUp({
-                            content: "❌ Invalid date. Use `YYYY-MM-DD` or `YYYY-MM-DD HH:MM` (24-hour, UTC) with a real date (e.g., not `2024-02-30`).",
+                            content: "Invalid date. Use `YYYY-MM-DD` or `YYYY-MM-DD HH:MM` (24-hour, UTC) with a real date (e.g., not `2024-02-99`).",
                             ephemeral: true
                         });
                         // Loop continues so they can try again on the same embed.

--- a/src/commands/config/ConfigQuotas.ts
+++ b/src/commands/config/ConfigQuotas.ts
@@ -328,7 +328,6 @@ export class ConfigQuotas extends BaseCommand {
 
                 const selectedValue = resetDoWPrompt.values[0];
 
-                // "Never" → store sentinel, clear timer, done.
                 if (selectedValue === "-1") {
                     ctx.guildDoc = await MongoManager.updateAndFetchGuildDoc({ guildId: ctx.guild!.id }, {
                         $set: {
@@ -345,7 +344,6 @@ export class ConfigQuotas extends BaseCommand {
                     break;
                 }
 
-                // Otherwise ask for time as usual
                 await botMsg!.edit({
                     embeds: [
                         new MessageEmbed()
@@ -409,7 +407,7 @@ export class ConfigQuotas extends BaseCommand {
             }
 
             case "panel_end": {
-                // We'll reuse the button interaction to send ephemeral followups.
+
                 const baseInt = selectedButton;
 
                 while (true) {
@@ -487,9 +485,6 @@ export class ConfigQuotas extends BaseCommand {
                             parsed = Date.parse(`${datePart}T${timePart}:00Z`);
                         }
                     }
-
-                    // Optional: reject past dates (remove this guard if you want to allow past)
-                    // if (!Number.isNaN(parsed) && parsed <= Date.now()) parsed = NaN;
 
                     if (!Number.isNaN(parsed)) {
                         ctx.guildDoc = await MongoManager.updateAndFetchGuildDoc(

--- a/src/commands/config/ConfigQuotas.ts
+++ b/src/commands/config/ConfigQuotas.ts
@@ -111,33 +111,58 @@ export class ConfigQuotas extends BaseCommand {
      * @param {Message} botMsg The bot message, which will be used for interactivity (editing message).
      */
     public async mainMenu(ctx: ICommandContext, botMsg: Message | null): Promise<void> {
+        const panelEndTime = ctx.guildDoc!.quotas.panelEndTime ?? null;
+        const resetInfo = ctx.guildDoc!.quotas.resetTime;
+
+        let resetLabel: string;
+        if (resetInfo.dayOfWeek === -1 || resetInfo.time === -1) {
+            resetLabel = "Never (manual reset only)";
+        } else {
+            const minutes = resetInfo.time % 100;
+            const timeReset = `${Math.floor(resetInfo.time / 100)}:${minutes < 10 ? "0" + minutes.toString() : minutes}`;
+            const dayOfWeekName = ConfigQuotas.DAYS_OF_WEEK[resetInfo.dayOfWeek][0];
+            resetLabel = `${dayOfWeekName} at ${timeReset}`;
+        }
+
         const buttons: MessageButton[] = [
             ButtonConstants.QUIT_BUTTON,
             new MessageButton()
                 .setLabel("Set Reset Time")
                 .setCustomId("reset_time")
                 .setStyle("PRIMARY")
-                .setEmoji(EmojiConstants.CLOCK_EMOJI)
+                .setEmoji(EmojiConstants.CLOCK_EMOJI),
+            new MessageButton()
+                .setLabel("Set Panel End Date")
+                .setCustomId("panel_end")
+                .setStyle("SECONDARY")
         ];
 
-        const resetInfo = ctx.guildDoc!.quotas.resetTime;
-        const dayOfWeek = ConfigQuotas.DAYS_OF_WEEK[resetInfo.dayOfWeek][0];
-        const seconds = resetInfo.time % 100;
-        const timeReset = `${Math.floor(resetInfo.time / 100)}:${seconds < 10 ? "0" + seconds.toString() : seconds}`;
+
         const embed: MessageEmbed = new MessageEmbed()
             .setAuthor({ name: ctx.guild!.name, iconURL: ctx.guild!.iconURL() ?? undefined })
             .setTitle("Quota Configuration Command")
             .setDescription(
-                "Here, you will be able to configure quotas for one or more roles. Select the appropriate option to"
-                + " begin."
-            ).addField(
+                "Here, you will be able to configure quotas for one or more roles. Select the appropriate option to begin."
+            )
+            .addField(
                 "Quit",
                 "Click on the `Quit` button to exit this process."
-            ).addField(
+            )
+            .addField(
                 "Set Reset Time",
-                "Click on the `Set Reset Time` button to set the time when all quotas will reset. The current reset"
-                + " time is:" + StringUtil.codifyString(`${dayOfWeek} at ${timeReset}`)
+                "Click on the `Set Reset Time` button to set when quotas will automatically reset. The current reset time is: "
+                + StringUtil.codifyString(resetLabel)
+            )
+            .addField(
+                "Set Panel End Date (Display Only)",
+                "Click on the `Set Panel End Date` button to set a **display-only** end date shown on all quota panels when using manual resets."
+                + " This does **not** automatically reset quotas."
+                + (panelEndTime
+                    ? `\nCurrent panel end date: <t:${Math.floor(panelEndTime / 1000)}:F>`
+                    : `\nCurrent panel end date: ${StringUtil.codifyString("Not Set")}`)
             );
+
+
 
         if (ctx.guildDoc!.quotas.quotaInfo.length + 1 < ConfigQuotas.MAX_QUOTAS_ALLOWED) {
             buttons.push(
@@ -260,8 +285,8 @@ export class ConfigQuotas extends BaseCommand {
                             .setAuthor({ name: ctx.guild!.name, iconURL: ctx.guild!.iconURL() ?? undefined })
                             .setTitle("Specify Day of Week for Reset")
                             .setDescription(
-                                "Select the day of the week that you want all quotas to reset at via the"
-                                + " dropdown menu."
+                                "Select the day of the week that you want all quotas to reset at via the dropdown menu."
+                                + " Select `Never` to disable automatic resets (manual reset only)."
                             )
                     ],
                     components: AdvancedCollector.getActionRowsFromComponents([
@@ -269,16 +294,20 @@ export class ConfigQuotas extends BaseCommand {
                             .setMaxValues(1)
                             .setMinValues(1)
                             .setCustomId("day_of_week")
-                            .addOptions(ConfigQuotas.DAYS_OF_WEEK.map(x => {
-                                const [dayOfWeekStr, dayOfWeekNum] = x;
-                                return {
+                            .addOptions([
+                                {
+                                    label: "Never (manual reset only)",
+                                    value: "-1"
+                                },
+                                ...ConfigQuotas.DAYS_OF_WEEK.map(([dayOfWeekStr, dayOfWeekNum]) => ({
                                     label: `${dayOfWeekStr} (${dayOfWeekNum})`,
                                     value: dayOfWeekNum.toString()
-                                };
-                            })),
+                                }))
+                            ]),
                         ButtonConstants.CANCEL_BUTTON
                     ])
                 });
+
                 const resetDoWPrompt = await AdvancedCollector.startInteractionCollector({
                     targetChannel: botMsg!.channel,
                     targetAuthor: ctx.user,
@@ -297,6 +326,26 @@ export class ConfigQuotas extends BaseCommand {
                 if (!resetDoWPrompt.isSelectMenu())
                     break;
 
+                const selectedValue = resetDoWPrompt.values[0];
+
+                // "Never" → store sentinel, clear timer, done.
+                if (selectedValue === "-1") {
+                    ctx.guildDoc = await MongoManager.updateAndFetchGuildDoc({ guildId: ctx.guild!.id }, {
+                        $set: {
+                            "quotas.resetTime.dayOfWeek": -1,
+                            "quotas.resetTime.time": -1
+                        }
+                    });
+
+                    if (QuotaManager.quotaTimeoutId) {
+                        clearTimeout(QuotaManager.quotaTimeoutId);
+                        QuotaManager.quotaTimeoutId = null;
+                    }
+
+                    break;
+                }
+
+                // Otherwise ask for time as usual
                 await botMsg!.edit({
                     embeds: [
                         new MessageEmbed()
@@ -335,7 +384,6 @@ export class ConfigQuotas extends BaseCommand {
                     const [hr, min] = m.content.split(":").map(x => Number.parseInt(x, 10));
                     if (Number.isNaN(hr) || hr < 0 || hr > 23)
                         return;
-
                     if (Number.isNaN(min) || min < 0 || min > 59)
                         return;
 
@@ -352,12 +400,97 @@ export class ConfigQuotas extends BaseCommand {
 
                 ctx.guildDoc = await MongoManager.updateAndFetchGuildDoc({ guildId: ctx.guild!.id }, {
                     $set: {
-                        "quotas.resetTime.dayOfWeek": Number.parseInt(resetDoWPrompt.values[0], 10),
+                        "quotas.resetTime.dayOfWeek": Number.parseInt(selectedValue, 10),
                         "quotas.resetTime.time": resetTimePrompt
                     }
                 });
+
                 break;
             }
+
+            case "panel_end": {
+                await botMsg!.edit({
+                    embeds: [
+                        new MessageEmbed()
+                            .setAuthor({ name: ctx.guild!.name, iconURL: ctx.guild!.iconURL() ?? undefined })
+                            .setTitle("Set Panel End Date (Display Only)")
+                            .setDescription(
+                                new StringBuilder()
+                                    .append("This sets a **display-only** end date used on all quota panels when using manual resets.")
+                                    .append(" It does **not** automatically reset quotas.")
+                                    .appendLine(2)
+                                    .append("Send a date/time in one of these formats (UTC/GMT):").appendLine()
+                                    .append("- `YYYY-MM-DD`").appendLine()
+                                    .append("- `YYYY-MM-DD HH:MM` (24-hour)").appendLine(2)
+                                    .append("Type `clear` to remove the panel end date.")
+                                    .toString()
+                            )
+                    ],
+                    components: AdvancedCollector.getActionRowsFromComponents([
+                        ButtonConstants.CANCEL_BUTTON
+                    ])
+                });
+
+                const res = await AdvancedCollector.startDoubleCollector<string>({
+                    cancelFlag: null,
+                    acknowledgeImmediately: true,
+                    clearInteractionsAfterComplete: false,
+                    deleteBaseMsgAfterComplete: false,
+                    deleteResponseMessage: true,
+                    duration: 2 * 60 * 1000,
+                    oldMsg: botMsg!,
+                    targetAuthor: ctx.user,
+                    targetChannel: botMsg!.channel as TextChannel
+                }, m => m.content.trim());
+
+                if (!res) {
+                    await this.dispose(ctx, botMsg);
+                    return;
+                }
+
+                if (res instanceof MessageComponentInteraction) {
+                    // Cancel button pressed.
+                    break;
+                }
+
+                const input = res.trim();
+
+                if (input.toLowerCase() === "clear") {
+                    ctx.guildDoc = await MongoManager.updateAndFetchGuildDoc(
+                        { guildId: ctx.guild!.id },
+                        { $set: { "quotas.panelEndTime": null } }
+                    );
+                    break;
+                }
+
+                let parsed: number = NaN;
+
+                // YYYY-MM-DD
+                if (/^\d{4}-\d{2}-\d{2}$/.test(input)) {
+                    parsed = Date.parse(input + "T00:00:00Z");
+                }
+                // YYYY-MM-DD HH:MM
+                else if (/^\d{4}-\d{2}-\d{2}\s+\d{1,2}:\d{2}$/.test(input)) {
+                    const [datePart, timePart] = input.split(/\s+/);
+                    const [hhStr, mmStr] = timePart.split(":");
+                    const hh = parseInt(hhStr, 10);
+                    const mm = parseInt(mmStr, 10);
+                    if (hh >= 0 && hh < 24 && mm >= 0 && mm < 60) {
+                        parsed = Date.parse(`${datePart}T${timePart}:00Z`);
+                    }
+                }
+
+                if (!Number.isNaN(parsed)) {
+                    ctx.guildDoc = await MongoManager.updateAndFetchGuildDoc(
+                        { guildId: ctx.guild!.id },
+                        { $set: { "quotas.panelEndTime": parsed } }
+                    );
+                }
+
+                break;
+            }
+
+
             case ButtonConstants.ADD_ID: {
                 await this.addOrEditQuota(ctx, botMsg);
                 return;
@@ -523,6 +656,7 @@ export class ConfigQuotas extends BaseCommand {
             ButtonConstants.QUIT_BUTTON
         ];
 
+
         while (true) {
             const role = await GuildFgrUtilities.fetchRole(ctx.guild!, quotaToEdit.roleId);
             saveButton.setDisabled(!role);
@@ -545,6 +679,7 @@ export class ConfigQuotas extends BaseCommand {
                 "Point Rules Set",
                 `${quotaToEdit.pointValues.length} Values Set`
             );
+
 
             await botMsg.edit({
                 embeds: [embed],
@@ -705,7 +840,7 @@ export class ConfigQuotas extends BaseCommand {
                             }
                         });
                     }
-                    const messageId = await QuotaManager.upsertLeaderboardMessage(quotaToEdit.messageId, quotaToEdit, ctx.guildDoc!);                    
+                    const messageId = await QuotaManager.upsertLeaderboardMessage(quotaToEdit.messageId, quotaToEdit, ctx.guildDoc!);
                     quotaToEdit.messageId = messageId;
 
                     ctx.guildDoc = await MongoManager.updateAndFetchGuildDoc({ guildId: ctx.guild!.id }, {

--- a/src/definitions/MongoDocumentInterfaces.ts
+++ b/src/definitions/MongoDocumentInterfaces.ts
@@ -407,12 +407,12 @@ export interface IGuildInfo {
         quotaInfo: IQuotaInfo[];
 
         /**
- * The display-only end timestamp for all quotas in this guild, in milliseconds. This is used for showing
- * when the quota period ends on quota panels across the guild, but does not affect the actual quota reset
- * logic. Only applicable when quotas are in manual mode.
- *
- * @type {number | null}
- */
+         * The display-only end timestamp for all quotas in this guild, in milliseconds. This is used for showing
+         * when the quota period ends on quota panels across the guild, but does not affect the actual quota reset
+         * logic. Only applicable when quotas are in manual mode.
+         *
+         * @type {number | null}
+         */
         panelEndTime?: number | null;
 
         /**

--- a/src/definitions/MongoDocumentInterfaces.ts
+++ b/src/definitions/MongoDocumentInterfaces.ts
@@ -407,6 +407,15 @@ export interface IGuildInfo {
         quotaInfo: IQuotaInfo[];
 
         /**
+ * The display-only end timestamp for all quotas in this guild, in milliseconds. This is used for showing
+ * when the quota period ends on quota panels across the guild, but does not affect the actual quota reset
+ * logic. Only applicable when quotas are in manual mode.
+ *
+ * @type {number | null}
+ */
+        panelEndTime?: number | null;
+
+        /**
          * The time when quotas should be reset. Times are based on GMT.
          *
          * @type {object}

--- a/src/managers/MongoManager.ts
+++ b/src/managers/MongoManager.ts
@@ -546,7 +546,9 @@ export namespace MongoManager {
                     // Sunday at 12:00 AM
                     dayOfWeek: 0,
                     time: 0
-                }
+                },
+                
+                panelEndTime: null
             }
         };
     }

--- a/src/managers/QuotaManager.ts
+++ b/src/managers/QuotaManager.ts
@@ -968,12 +968,12 @@ export namespace QuotaManager {
                     nextReset = diff;
                     LOGGER.info(`Found a more suitable end time: ${TimeUtilities.formatDuration(nextReset, false)}`);
                 } else if (diff < 0) {
-                    // Past due → reset now
+
                     const role = await GuildFgrUtilities.fetchRole(guild, quotaInfo.roleId);
                     LOGGER.info(`Reset quota for ${role?.name} in ${guild.name}`);
                     await QuotaManager.resetQuota(guild, quotaInfo.roleId);
                 } else {
-                    // Not due yet → just make sure embed reflects current config
+
                     await upsertLeaderboardMessage(quotaInfo.messageId, quotaInfo, guildDoc);
                 }
             }

--- a/src/managers/QuotaManager.ts
+++ b/src/managers/QuotaManager.ts
@@ -349,7 +349,7 @@ export namespace QuotaManager {
      * @return {string | null} The best role ID corresponding to the quota to log, if any. `null` otherwise.
      */
     export function findBestQuotaToAdd(member: GuildMember, guildDoc: IGuildInfo, logType: QuotaLogType,
-        dungeonId?: string): string | null {
+                                       dungeonId?: string): string | null {
         LOGGER.info(`Finding best quota to add ${logType} for ${member.displayName}`);
         let resolvedLogType: string = logType;
         if (logType === "RunAssist" || logType === "RunComplete" || logType === "RunFailed") {
@@ -450,7 +450,7 @@ export namespace QuotaManager {
      * @param {number} amt The amount of said action to log.
      */
     export async function logQuota(member: GuildMember, roleId: string, logType: string,
-        amt: number): Promise<void> {
+                                   amt: number): Promise<void> {
         LOGGER.info(`Logging quota for ${member.displayName}, role: ${MiscUtilities.getRoleName(roleId, member.guild)}, type: ${logType}, amount: ${amt}`);
         const guildDoc = await MongoManager.updateAndFetchGuildDoc({
             guildId: member.guild.id,
@@ -573,7 +573,7 @@ export namespace QuotaManager {
      * assists, or failures.
      */
     export async function logQuotaInteractive(obj: Message | GuildMember, logType: QuotaLogType,
-        amt: number, dungeonId?: string): Promise<boolean> {
+                                              amt: number, dungeonId?: string): Promise<boolean> {
         let resolvedLogType: string = logType;
         if (logType === "RunAssist" || logType === "RunComplete" || logType === "RunFailed") {
             if (!dungeonId) return false;
@@ -813,7 +813,7 @@ export namespace QuotaManager {
                 );
             } else {
                 embed.setDescription(
-                    embed.description + `\n- End Time: Manual reset only`
+                    embed.description + "\n- End Time: Manual reset only"
                 );
             }
         }

--- a/src/managers/QuotaManager.ts
+++ b/src/managers/QuotaManager.ts
@@ -63,7 +63,7 @@ export namespace QuotaManager {
     const IGNORE_RESET_TIME = 100_000;
 
     // Id to keep track of timeouts set so they don't eventually spam if the bot process isn't cleared
-    export let quotaTimeoutId: NodeJS.Timeout;
+    export let quotaTimeoutId: NodeJS.Timeout | null = null;
 
     /**
      * Checks if the string is of some quota type.
@@ -94,249 +94,233 @@ export namespace QuotaManager {
     export async function resetQuota(guild: Guild, roleId: string): Promise<boolean> {
         LOGGER.info(`Resetting quota for roleid ${MiscUtilities.getRoleName(roleId, guild)}`);
 
-        const guildDoc = await MongoManager.getOrCreateGuildDoc(guild, true);
-        if (!guildDoc)
-            return false;
+        try {
+            const guildDoc = await MongoManager.getOrCreateGuildDoc(guild, true);
+            if (!guildDoc) return false;
 
-        const oldQuotas = guildDoc.quotas.quotaInfo.find(x => x.roleId === roleId);
-        if (!oldQuotas)
-            return false;
+            const oldQuotas = guildDoc.quotas.quotaInfo.find(x => x.roleId === roleId);
+            if (!oldQuotas) return false;
 
-        // No channel = pull from database since we can't update it
-        const quotaChannel = GuildFgrUtilities.getCachedChannel<TextChannel>(guild, oldQuotas.channel);
-        if (!quotaChannel) {
-            await MongoManager.updateAndFetchGuildDoc({ guildId: guild.id }, {
-                $pull: {
-                    "quotas.quotaInfo.roleId": roleId
-                }
-            });
-            return false;
-        }
+            const quotaChannel = GuildFgrUtilities.getCachedChannel<TextChannel>(guild, oldQuotas.channel);
 
-        const role = await GuildFgrUtilities.fetchRole(guild, roleId);
-        // TODO this seems like a very poor idea on my part
-        await guild.members.fetch();
-        const quotaMsg = await GuildFgrUtilities.fetchMessage(quotaChannel, oldQuotas.messageId);
-        // Only care about quota actions worth points
-        const quotaLogMap = new Collection<string, number>();
-        for (const { key, value } of oldQuotas.pointValues) {
-            if (value === 0) continue;
-            quotaLogMap.set(key, value);
-        }
-
-        // Sort all data into a map for easier use
-        // key = user ID
-        const quotaPointMap = new Collection<string, {
-            points: number;
-            quotaBreakdown: {
-                [quotaType: string]: { pts: number; qty: number; breakdown: string[] };
-            };
-        }>();
-
-        if (role) {
-            for (const [id,] of role.members) {
-                quotaPointMap.set(id, {
-                    points: 0,
-                    quotaBreakdown: {}
-                });
-            }
-        }
-
-        for (const logInfo of oldQuotas.quotaLog) {
-            if (!quotaPointMap.has(logInfo.userId)) {
-                quotaPointMap.set(logInfo.userId, {
-                    points: 0,
-                    quotaBreakdown: {}
-                });
+            // If channel is gone, remove the quota config and bail gracefully
+            if (!quotaChannel) {
+                await MongoManager.updateAndFetchGuildDoc(
+                    { guildId: guild.id },
+                    { $pull: { "quotas.quotaInfo": { roleId } } }
+                );
+                LOGGER.warn(`Quota channel missing; removed quota config for role ${roleId}`);
+                return true;
             }
 
-            const baseRule = logInfo.logType.split(":")[0];
-            let ruleToLog = logInfo.logType;
-            if (quotaLogMap.has(baseRule)) {
-                ruleToLog = baseRule;
+            const role = await GuildFgrUtilities.fetchRole(guild, roleId);
+
+            // Build a “points per key” map (skip zero-point rules)
+            const quotaLogMap = new Collection<string, number>();
+            for (const { key, value } of oldQuotas.pointValues) {
+                if (value !== 0) quotaLogMap.set(key, value);
             }
 
-            if (!quotaLogMap.has(ruleToLog)) continue;
-
-            const points = quotaLogMap.get(ruleToLog)!;
-            const pointLogEntry = quotaPointMap.get(logInfo.userId)!;
-
-            pointLogEntry.points += points * logInfo.amount;
-            if (!pointLogEntry.quotaBreakdown[ruleToLog]) {
-                pointLogEntry.quotaBreakdown[ruleToLog] = {
-                    qty: logInfo.amount,
-                    pts: points * logInfo.amount,
-                    breakdown: [
-                        `\t\t\t[${TimeUtilities.getDateTime(logInfo.timeIssued)}] Logged ${logInfo.amount} QTY.`
-                    ]
+            // Aggregate user points (only members we actually see in cache)
+            const quotaPointMap = new Collection<string, {
+                points: number;
+                quotaBreakdown: {
+                    [quotaType: string]: { pts: number; qty: number; breakdown: string[] };
                 };
-                continue;
+            }>();
+
+            if (role) {
+                for (const [id] of role.members) {
+                    quotaPointMap.set(id, { points: 0, quotaBreakdown: {} });
+                }
             }
 
-            pointLogEntry.quotaBreakdown[ruleToLog].qty += logInfo.amount;
-            pointLogEntry.quotaBreakdown[ruleToLog].pts += points * logInfo.amount;
-            pointLogEntry.quotaBreakdown[ruleToLog].breakdown.push(
-                `\t\t\t[${TimeUtilities.getDateTime(logInfo.timeIssued)}] Logged ${logInfo.amount} QTY.`
-            );
-        }
+            for (const logInfo of oldQuotas.quotaLog) {
+                if (!quotaPointMap.has(logInfo.userId)) {
+                    quotaPointMap.set(logInfo.userId, { points: 0, quotaBreakdown: {} });
+                }
 
-        // Process it so it can be put in a text file
-        const arrStrArr: string[] = [];
-        const memberIds = Array.from(quotaPointMap.keys());
-        const members = await Promise.all(memberIds.map(x => GuildFgrUtilities.fetchGuildMember(guild, x)));
-        for (let i = 0; i < members.length; i++) {
-            const logInfo = quotaPointMap.get(memberIds[i])!;
-            const memberDisplay = members[i]?.displayName ?? memberIds[i];
-            const status = logInfo.points >= oldQuotas.pointsNeeded
-                ? " Complete  "
-                : logInfo.points > 0
-                    ? "Incomplete "
-                    : "Not Started";
-            const sb = new StringBuilder()
-                .append(`- [${status}] ${memberDisplay}: ${logInfo.points}/${oldQuotas.pointsNeeded}`)
-                .appendLine()
-                .append(`\tUser Tag (ID): ${members[i]?.user.tag ?? "N/A"} (${memberIds[i]})`)
-                .appendLine()
-                .append(`\tRoles: [${members[i]?.roles.cache.map(x => x.name).join(", ") ?? ""}]`)
-                .appendLine()
-                .append("\tBreakdown:")
-                .appendLine();
-            const entries = Object.entries(logInfo.quotaBreakdown);
-            if (entries.length === 0) {
-                sb.append("\t\t- None Available.")
+                const baseRule = logInfo.logType.split(":")[0];
+                let ruleToLog = logInfo.logType;
+                if (quotaLogMap.has(baseRule)) ruleToLog = baseRule;
+
+                if (!quotaLogMap.has(ruleToLog)) continue;
+
+                const pts = quotaLogMap.get(ruleToLog)!;
+                const pointLogEntry = quotaPointMap.get(logInfo.userId)!;
+
+                pointLogEntry.points += pts * logInfo.amount;
+                if (!pointLogEntry.quotaBreakdown[ruleToLog]) {
+                    pointLogEntry.quotaBreakdown[ruleToLog] = {
+                        qty: logInfo.amount,
+                        pts: pts * logInfo.amount,
+                        breakdown: [
+                            `\t\t\t[${TimeUtilities.getDateTime(logInfo.timeIssued)}] Logged ${logInfo.amount} QTY.`
+                        ]
+                    };
+                } else {
+                    pointLogEntry.quotaBreakdown[ruleToLog].qty += logInfo.amount;
+                    pointLogEntry.quotaBreakdown[ruleToLog].pts += pts * logInfo.amount;
+                    pointLogEntry.quotaBreakdown[ruleToLog].breakdown.push(
+                        `\t\t\t[${TimeUtilities.getDateTime(logInfo.timeIssued)}] Logged ${logInfo.amount} QTY.`
+                    );
+                }
+            }
+
+            // Build summary text (unchanged from your logic, just wrapped safely)
+            const arrStrArr: string[] = [];
+            const memberIds = Array.from(quotaPointMap.keys());
+            const members = await Promise.all(memberIds.map(x => GuildFgrUtilities.fetchGuildMember(guild, x)));
+
+            for (let i = 0; i < members.length; i++) {
+                const logInfo = quotaPointMap.get(memberIds[i])!;
+                const memberDisplay = members[i]?.displayName ?? memberIds[i];
+                const status = logInfo.points >= oldQuotas.pointsNeeded
+                    ? " Complete  "
+                    : logInfo.points > 0
+                        ? "Incomplete "
+                        : "Not Started";
+
+                const sb = new StringBuilder()
+                    .append(`- [${status}] ${memberDisplay}: ${logInfo.points}/${oldQuotas.pointsNeeded}`)
+                    .appendLine()
+                    .append(`\tUser Tag (ID): ${members[i]?.user.tag ?? "N/A"} (${memberIds[i]})`)
+                    .appendLine()
+                    .append(`\tRoles: [${members[i]?.roles.cache.map(x => x.name).join(", ") ?? ""}]`)
+                    .appendLine()
+                    .append("\tBreakdown:")
                     .appendLine();
-            }
-            else {
-                for (const [quotaType, { pts, qty, breakdown }] of entries) {
-                    // Need to look into quota types like `RunComplete:DUNGEON_ID` or `Parse`.
-                    const logArr = quotaType.split(":");
-                    if (logArr.length === 2) {
-                        // We assume the second element is the dungeon ID.
-                        // Get the dungeon name
-                        const dungeonName = (DungeonUtilities.isCustomDungeon(logArr[1])
-                            ? guildDoc.properties.customDungeons.find(x => x.codeName === logArr[1])?.dungeonName
-                            : DUNGEON_DATA.find(x => x.codeName === logArr[1])?.dungeonName) ?? logArr[1];
 
-                        sb.append(`\t\t- ${logArr[0]} (${dungeonName}): ${pts} PTS (${qty})`)
-                            .appendLine()
-                            .append(breakdown.join("\n"))
-                            .appendLine();
-                        continue;
+                const entries = Object.entries(logInfo.quotaBreakdown);
+                if (entries.length === 0) {
+                    sb.append("\t\t- None Available.").appendLine();
+                } else {
+                    for (const [quotaType, { pts, qty, breakdown }] of entries) {
+                        const logArr = quotaType.split(":");
+                        if (logArr.length === 2) {
+                            const dungeonName = (DungeonUtilities.isCustomDungeon(logArr[1])
+                                ? guildDoc.properties.customDungeons.find(x => x.codeName === logArr[1])?.dungeonName
+                                : DUNGEON_DATA.find(x => x.codeName === logArr[1])?.dungeonName) ?? logArr[1];
+
+                            sb.append(`\t\t- ${logArr[0]} (${dungeonName}): ${pts} PTS (${qty})`)
+                                .appendLine()
+                                .append(breakdown.join("\n"))
+                                .appendLine();
+                        } else {
+                            sb.append(`\t\t- ${quotaType}: ${pts} PTS (${qty})`)
+                                .appendLine()
+                                .append(breakdown.join("\n"))
+                                .appendLine();
+                        }
                     }
+                }
 
-                    sb.append(`\t\t- ${quotaType}: ${pts} PTS (${qty})`)
-                        .appendLine()
-                        .append(breakdown.join("\n"))
-                        .appendLine();
+                arrStrArr.push(sb.toString().trim());
+            }
+
+            const finalSummaryStr = new StringBuilder()
+                .append("================= QUOTA SUMMARY =================").appendLine()
+                .append(`- Role: ${MiscUtilities.getRoleName(oldQuotas.roleId, guild)}`)
+                .append(`- Start Time: ${TimeUtilities.getDateTime(oldQuotas.lastReset)} GMT`).appendLine()
+                .append(`- End Time: ${TimeUtilities.getDateTime(Date.now())} GMT`).appendLine()
+                .append(`- Members w/ Role: ${role?.members.size ?? "N/A"}`).appendLine()
+                .append(`- Minimum Points Needed: ${oldQuotas.pointsNeeded}`).appendLine(2)
+                .append("================= POINT SUMMARY =================").appendLine()
+                .append(getPointListAsString(guildDoc, oldQuotas)).appendLine(2)
+                .append("================= MEMBER SUMMARY =================").appendLine()
+                .append(arrStrArr.join("\n"))
+                .toString();
+
+            const storageChannel = await MongoManager.getStorageChannel(guild);
+            const channelToUse = storageChannel ? storageChannel : quotaChannel;
+
+            let urlToFile: string | null = null;
+            const fileName = (`quota_${guild.name.replaceAll(" ", "-")}_${MiscUtilities.getRoleName(roleId, guild).replaceAll(" ", "-")}_${Date.now()}.txt`);
+
+            if (channelToUse) {
+                const storageMsg = await GlobalFgrUtilities.sendMsg(
+                    channelToUse,
+                    {
+                        files: [
+                            new MessageAttachment(Buffer.from(finalSummaryStr, "utf8"), fileName)
+                        ]
+                    }
+                ).catch(LOGGER.error);
+
+                if (storageMsg) urlToFile = storageMsg.attachments.first()?.url ?? null;
+            }
+
+            const descSb = new StringBuilder()
+                .append(`- Start Time: ${TimeUtilities.getDiscordTime({ time: oldQuotas.lastReset, style: TimestampType.FullDateNoDay })}`).appendLine()
+                .append(`- End Time: ${TimeUtilities.getDiscordTime({ style: TimestampType.FullDateNoDay })}`).appendLine()
+                .append(`- Members w/ Role: \`${role?.members.size ?? "N/A"}\``).appendLine()
+                .append(`- Minimum Points Needed: \`${oldQuotas.pointsNeeded}\``).appendLine();
+            if (!role) {
+                descSb.append("- Warning: This role was not found; it might have been deleted. This role has been removed from the quota system.");
+            }
+
+            const summaryEmbed = MessageUtilities.generateBlankEmbed(guild, "RANDOM")
+                .setTitle(`Inactive Quota - Summary: **${role?.name ?? "ID " + roleId}**`)
+                .setDescription(descSb.toString())
+                .setTimestamp();
+
+            if (urlToFile) {
+                summaryEmbed.addField(
+                    "Summary",
+                    `Click [here](${urlToFile}) to get this quota period's summary. This will download a file.`
+                );
+            } else {
+                const fields = ArrayUtilities.arrayToStringFields(arrStrArr, (_, elem) => elem);
+                for (const field of fields) {
+                    summaryEmbed.addField(GeneralConstants.ZERO_WIDTH_SPACE, field);
                 }
             }
 
-            arrStrArr.push(sb.toString().trim());
-        }
-
-        // If there's nothing to update, then we don't need to send inactive quota
-        const finalSummaryStr = new StringBuilder()
-            .append("================= QUOTA SUMMARY =================").appendLine()
-            .append(`- Role: ${MiscUtilities.getRoleName(oldQuotas.roleId, guild)}`)
-            .append(`- Start Time: ${TimeUtilities.getDateTime(oldQuotas.lastReset)} GMT`).appendLine()
-            .append(`- End Time: ${TimeUtilities.getDateTime(Date.now())} GMT`).appendLine()
-            .append(`- Members w/ Role: ${role?.members.size ?? "N/A"}`).appendLine()
-            .append(`- Minimum Points Needed: ${oldQuotas.pointsNeeded}`).appendLine(2)
-            .append("================= POINT SUMMARY =================").appendLine()
-            .append(getPointListAsString(guildDoc, oldQuotas)).appendLine(2)
-            .append("================= MEMBER SUMMARY =================").appendLine()
-            .append(arrStrArr.join("\n"))
-            .toString();
-        const storageChannel = await MongoManager.getStorageChannel(guild);
-        const channelToUse = storageChannel ? storageChannel : quotaChannel;
-        let urlToFile: string | null = null;
-        const fileName = (`quota_${guild.name.replaceAll(" ", "-")}_${MiscUtilities.getRoleName(roleId, guild).replaceAll(" ", "-")}_${Date.now()}.txt`);
-        if (channelToUse) {
-            const storageMsg = await GlobalFgrUtilities.sendMsg(
-                channelToUse,
-                {
-                    files: [
-                        new MessageAttachment(Buffer.from(finalSummaryStr, "utf8"),
-                            fileName)
-                    ]
-                }
-            ).catch(LOGGER.error);
-
-            if (storageMsg)
-                urlToFile = storageMsg.attachments.first()!.url;
-        }
-
-        const descSb = new StringBuilder()
-            .append(`- Start Time: ${TimeUtilities.getDiscordTime({ time: oldQuotas.lastReset, style: TimestampType.FullDateNoDay })}`).appendLine()
-            .append(`- End Time: ${TimeUtilities.getDiscordTime({ style: TimestampType.FullDateNoDay })}`).appendLine()
-            .append(`- Members w/ Role: \`${role?.members.size ?? "N/A"}\``).appendLine()
-            .append(`- Minimum Points Needed: \`${oldQuotas.pointsNeeded}\``).appendLine();
-        if (!role) {
-            descSb.append("- Warning: This role was not found; it might have been deleted. This role has been ")
-                .append("removed from the quota system.");
-        }
-
-        const summaryEmbed = MessageUtilities.generateBlankEmbed(guild, "RANDOM")
-            .setTitle(`Inactive Quota - Summary: **${role?.name ?? "ID " + roleId}**`)
-            .setDescription(descSb.toString())
-            .setTimestamp();
-        if (urlToFile) {
-            summaryEmbed.addField(
-                "Summary",
-                `Click [here](${urlToFile}) to get this quota period's summary. This will download a file.`
-            );
-        }
-        else {
-            const fields = ArrayUtilities.arrayToStringFields(
-                arrStrArr,
-                (_, elem) => elem
-            );
-            for (const field of fields) {
-                summaryEmbed.addField(GeneralConstants.ZERO_WIDTH_SPACE, field);
+            const quotaMsg = await GuildFgrUtilities.fetchMessage(quotaChannel, oldQuotas.messageId);
+            if (quotaMsg) {
+                await quotaMsg.edit({ embeds: [summaryEmbed] }).catch(LOGGER.error);
+                await quotaMsg.unpin().catch(LOGGER.error);
+            } else {
+                await quotaChannel.send({ embeds: [summaryEmbed] }).catch(LOGGER.error);
             }
-        }
 
-        if (quotaMsg) {
-            await quotaMsg.edit({ embeds: [summaryEmbed] });
-            quotaMsg.unpin().catch(LOGGER.error);
-        }
-        else
-            await quotaChannel.send({ embeds: [summaryEmbed] });
+            // Finally, clear logs & upsert a fresh leaderboard message
+            const startTime = new Date();
 
-        const startTime = new Date();
+            if (role) {
+                oldQuotas.quotaLog = [];
+                oldQuotas.lastReset = startTime.getTime();
 
-        if (role) {
-            oldQuotas.quotaLog = [];
-            oldQuotas.lastReset = startTime.getTime();
-            const newMsg: Message = await quotaChannel.send({
-                embeds: [
-                    (await getQuotaLeaderboardEmbed(guild, guildDoc, oldQuotas))!
-                ]
-            });
+                const newMsg = await quotaChannel.send({
+                    embeds: [(await getQuotaLeaderboardEmbed(guild, guildDoc, oldQuotas))!]
+                }).catch(LOGGER.error);
 
-            newMsg.pin().catch(LOGGER.error);
-
-            await MongoManager.updateAndFetchGuildDoc({
-                guildId: guild.id,
-                "quotas.quotaInfo.roleId": roleId
-            }, {
-                $set: {
-                    "quotas.quotaInfo.$.quotaLog": [],
-                    "quotas.quotaInfo.$.lastReset": startTime.getTime(),
-                    "quotas.quotaInfo.$.messageId": newMsg.id
+                if (newMsg) {
+                    await newMsg.pin().catch(LOGGER.error);
+                    await MongoManager.updateAndFetchGuildDoc({
+                        guildId: guild.id,
+                        "quotas.quotaInfo.roleId": roleId
+                    }, {
+                        $set: {
+                            "quotas.quotaInfo.$.quotaLog": [],
+                            "quotas.quotaInfo.$.lastReset": startTime.getTime(),
+                            "quotas.quotaInfo.$.messageId": newMsg.id
+                        }
+                    });
                 }
-            });
-        }
-        else {
-            await MongoManager.updateAndFetchGuildDoc({ guildId: guild.id }, {
-                $pull: {
-                    "quotas.quotaInfo.roleId": roleId
-                }
-            });
-        }
+            } else {
+                await MongoManager.updateAndFetchGuildDoc({ guildId: guild.id }, {
+                    $pull: { "quotas.quotaInfo": { roleId } }
+                });
+            }
 
-        return true;
+            return true;
+        } catch (err) {
+            LOGGER.error(`resetQuota failed for role ${roleId}: ${String(err)}`);
+            return false;
+        }
     }
+
 
     /**
      * Resets all quotas.
@@ -365,7 +349,7 @@ export namespace QuotaManager {
      * @return {string | null} The best role ID corresponding to the quota to log, if any. `null` otherwise.
      */
     export function findBestQuotaToAdd(member: GuildMember, guildDoc: IGuildInfo, logType: QuotaLogType,
-                                       dungeonId?: string): string | null {
+        dungeonId?: string): string | null {
         LOGGER.info(`Finding best quota to add ${logType} for ${member.displayName}`);
         let resolvedLogType: string = logType;
         if (logType === "RunAssist" || logType === "RunComplete" || logType === "RunFailed") {
@@ -466,7 +450,7 @@ export namespace QuotaManager {
      * @param {number} amt The amount of said action to log.
      */
     export async function logQuota(member: GuildMember, roleId: string, logType: string,
-                                   amt: number): Promise<void> {
+        amt: number): Promise<void> {
         LOGGER.info(`Logging quota for ${member.displayName}, role: ${MiscUtilities.getRoleName(roleId, member.guild)}, type: ${logType}, amount: ${amt}`);
         const guildDoc = await MongoManager.updateAndFetchGuildDoc({
             guildId: member.guild.id,
@@ -589,7 +573,7 @@ export namespace QuotaManager {
      * assists, or failures.
      */
     export async function logQuotaInteractive(obj: Message | GuildMember, logType: QuotaLogType,
-                                              amt: number, dungeonId?: string): Promise<boolean> {
+        amt: number, dungeonId?: string): Promise<boolean> {
         let resolvedLogType: string = logType;
         if (logType === "RunAssist" || logType === "RunComplete" || logType === "RunFailed") {
             if (!dungeonId) return false;
@@ -762,60 +746,103 @@ export namespace QuotaManager {
      * @returns {Promise<MessageEmbed | null>} The embed, if any. `null` only if the role corresponding to the quota
      * could not be found.
      */
-    export async function getQuotaLeaderboardEmbed(guild: Guild, guildDoc: IGuildInfo,
-                                                   quotaInfo: IQuotaInfo): Promise<MessageEmbed | null> {
+    export async function getQuotaLeaderboardEmbed(
+        guild: Guild,
+        guildDoc: IGuildInfo,
+        quotaInfo: IQuotaInfo
+    ): Promise<MessageEmbed | null> {
         LOGGER.debug(`Getting Quota Leaderboard Embed: ${MiscUtilities.getRoleName(quotaInfo.roleId, guild)}`);
+
         const role = GuildFgrUtilities.getCachedRole(guild, quotaInfo.roleId);
         if (!role)
             return null;
 
         const startTime = quotaInfo.lastReset;
-        const endTime = TimeUtilities.getNextDate(
-            quotaInfo.lastReset,
-            guildDoc.quotas.resetTime.dayOfWeek,
-            guildDoc.quotas.resetTime.time
-        );
-        const timeLeft = TimeUtilities.getDiscordTime({ time: endTime.getTime() });
+        const { dayOfWeek, time } = guildDoc.quotas.resetTime;
+        const panelEndTime = guildDoc.quotas.panelEndTime ?? null;
+
+
 
         const quotaPtDisplay = getPointListAsString(guildDoc, quotaInfo);
+
+        const baseDesc = new StringBuilder()
+            .append(`- Start Time: ${TimeUtilities.getDiscordTime({ time: startTime, style: TimestampType.FullDateNoDay })}`).appendLine()
+            .append(`- Members w/ Role: \`${role.members.size}\``).appendLine()
+            .append(`- Minimum Points Needed: \`${quotaInfo.pointsNeeded}\``).appendLine()
+            .append("__**Point Values**__")
+            .append(
+                StringUtil.codifyString(
+                    quotaPtDisplay.length === 0
+                        ? "N/A"
+                        : quotaPtDisplay
+                )
+            )
+            .toString();
+
         const embed = MessageUtilities.generateBlankEmbed(guild, "RANDOM")
             .setTitle(`Active Quota: ${role.name}`)
-            .setDescription(
-                new StringBuilder()
-                    .append(`- Start Time: ${TimeUtilities.getDiscordTime({ time: startTime, style: TimestampType.FullDateNoDay })}`).appendLine()
-                    .append(`- End Time: ${TimeUtilities.getDiscordTime({ time: endTime.getTime(), style: TimestampType.FullDateNoDay })}`).appendLine()
-                    .append(`- Members w/ Role: \`${role.members.size}\``).appendLine()
-                    .append(`- Minimum Points Needed: \`${quotaInfo.pointsNeeded}\``).appendLine()
-                    .append("__**Point Values**__")
-                    .append(
-                        StringUtil.codifyString(
-                            quotaPtDisplay.length === 0
-                                ? "N/A"
-                                : quotaPtDisplay
-                        )
-                    )
-                    .toString()
-            )
+            .setDescription(baseDesc)
             .setTimestamp();
 
-        if (quotaInfo.quotaLog.length === 0)
-            return embed.addField("**__Time left__**", `Quota period ends ${timeLeft}`);
+        let timeLeftLabel: string | null = null;
 
+        // Auto-reset mode
+        if (dayOfWeek !== -1 && time !== -1) {
+            const endTime = TimeUtilities.getNextDate(startTime, dayOfWeek, time);
+            const endTimeDisplay = TimeUtilities.getDiscordTime({
+                time: endTime.getTime(),
+                style: TimestampType.FullDateNoDay
+            });
+
+            embed.setDescription(
+                embed.description + `\n- End Time: ${endTimeDisplay}`
+            );
+
+            timeLeftLabel = `Quota period ends ${TimeUtilities.getDiscordTime({ time: endTime.getTime() })}`;
+        }
+        // Manual-only mode
+        else {
+            if (panelEndTime) {
+                const endDisplay = TimeUtilities.getDiscordTime({
+                    time: panelEndTime,
+                    style: TimestampType.FullDateNoDay
+                });
+
+                embed.setDescription(
+                    embed.description + `\n- End Time: ${endDisplay}`
+                );
+            } else {
+                embed.setDescription(
+                    embed.description + `\n- End Time: Manual reset only`
+                );
+            }
+        }
+
+
+        // No logs: just show time left if applicable
+        if (quotaInfo.quotaLog.length === 0) {
+            if (timeLeftLabel) {
+                embed.addField("**__Time left__**", timeLeftLabel);
+            }
+            return embed;
+        }
+
+        // Build leaderboard
         const points: [GuildMember | string, number][] = [];
         const memberIdSeen = new Set<string>();
+
         for (const { userId } of quotaInfo.quotaLog) {
             if (memberIdSeen.has(userId))
                 continue;
             memberIdSeen.add(userId);
+
             const member = await GuildFgrUtilities.fetchGuildMember(guild, userId);
-            if (member && member.roles.cache.has(role.id))
-                points.push([member ?? userId, calcTotalQuotaPtsForMember(userId, role.id, guildDoc)]);
+            if (member && member.roles.cache.has(role.id)) {
+                points.push([member, calcTotalQuotaPtsForMember(userId, role.id, guildDoc)]);
+            }
         }
 
-        const leaderboard = ArrayUtilities.generateLeaderboardArray(
-            points,
-            p => p[1]
-        );
+        const leaderboard = ArrayUtilities.generateLeaderboardArray(points, p => p[1]);
 
         const fields = ArrayUtilities.arrayToStringFields(
             leaderboard,
@@ -840,8 +867,13 @@ export namespace QuotaManager {
             initialAdded = true;
         }
 
-        return embed.addField("**__Time left__**", `Quota period ends ${timeLeft}`);
+        if (timeLeftLabel) {
+            embed.addField("**__Time left__**", timeLeftLabel);
+        }
+
+        return embed;
     }
+
 
     /**
      * Sends or edits an existing quota leaderboard with the most recent leaderboard
@@ -903,38 +935,66 @@ export namespace QuotaManager {
      */
     export async function checkForReset() {
         const guildDocs = await MongoManager.getGuildCollection().find().toArray();
+
         let nextReset = DEFAULT_CHECK_RESET;
+        let hasAutoResetGuild = false;
 
         for (const guildDoc of guildDocs) {
             const guild = GlobalFgrUtilities.getCachedGuild(guildDoc.guildId);
-
             if (!guild) continue;
 
-            guildDoc.quotas.quotaInfo.forEach(async (quotaInfo) => {
+            const { dayOfWeek, time } = guildDoc.quotas.resetTime;
+
+            // Manual-only mode: update embeds if you want, but don't schedule resets
+            if (dayOfWeek === -1 || time === -1) {
+                for (const quotaInfo of guildDoc.quotas.quotaInfo) {
+                    await upsertLeaderboardMessage(quotaInfo.messageId, quotaInfo, guildDoc);
+                }
+                continue;
+            }
+
+            hasAutoResetGuild = true;
+
+            for (const quotaInfo of guildDoc.quotas.quotaInfo) {
                 const endTime = TimeUtilities.getNextDate(
                     quotaInfo.lastReset,
-                    guildDoc.quotas.resetTime.dayOfWeek,
-                    guildDoc.quotas.resetTime.time
+                    dayOfWeek,
+                    time
                 );
 
-                if (endTime.getTime() > Date.now() && (endTime.getTime() - Date.now() < nextReset) && (endTime.getTime() - Date.now() > IGNORE_RESET_TIME)) {
-                    nextReset = endTime.getTime() - Date.now();
+                const diff = endTime.getTime() - Date.now();
+
+                if (diff > IGNORE_RESET_TIME && diff < nextReset) {
+                    nextReset = diff;
                     LOGGER.info(`Found a more suitable end time: ${TimeUtilities.formatDuration(nextReset, false)}`);
-                } else if (endTime.getTime() - Date.now() < 0) {
-                    // If the date has already passed, it needs to be reset
+                } else if (diff < 0) {
+                    // Past due → reset now
                     const role = await GuildFgrUtilities.fetchRole(guild, quotaInfo.roleId);
                     LOGGER.info(`Reset quota for ${role?.name} in ${guild.name}`);
                     await QuotaManager.resetQuota(guild, quotaInfo.roleId);
                 } else {
-                    // Otherwise, the date has not passed. Update the embed incase there has been any changes (reset time)
+                    // Not due yet → just make sure embed reflects current config
                     await upsertLeaderboardMessage(quotaInfo.messageId, quotaInfo, guildDoc);
                 }
-            });
+            }
         }
 
-        if (nextReset === DEFAULT_CHECK_RESET)
+        // If no guild has auto reset configured, stop scheduling.
+        if (!hasAutoResetGuild) {
+            LOGGER.info("No auto quota resets configured. Auto reset timer cleared.");
+            if (quotaTimeoutId) {
+                clearTimeout(quotaTimeoutId);
+                quotaTimeoutId = null;
+            }
+            return;
+        }
+
+        if (nextReset === DEFAULT_CHECK_RESET) {
             LOGGER.info("Could not find a new time to check for quota resets. Defaulting to 1 day.");
+        }
 
         quotaTimeoutId = setTimeout(checkForReset, nextReset);
     }
+
+
 }

--- a/src/managers/QuotaManager.ts
+++ b/src/managers/QuotaManager.ts
@@ -176,9 +176,9 @@ export namespace QuotaManager {
                 const logInfo = quotaPointMap.get(memberIds[i])!;
                 const memberDisplay = members[i]?.displayName ?? memberIds[i];
                 const status = logInfo.points >= oldQuotas.pointsNeeded
-                    ? " Complete  "
+                    ? "Complete"
                     : logInfo.points > 0
-                        ? "Incomplete "
+                        ? "Incomplete"
                         : "Not Started";
 
                 const sb = new StringBuilder()
@@ -759,9 +759,6 @@ export namespace QuotaManager {
 
         const startTime = quotaInfo.lastReset;
         const { dayOfWeek, time } = guildDoc.quotas.resetTime;
-        const panelEndTime = guildDoc.quotas.panelEndTime ?? null;
-
-
 
         const quotaPtDisplay = getPointListAsString(guildDoc, quotaInfo);
 
@@ -802,6 +799,8 @@ export namespace QuotaManager {
         }
         // Manual-only mode
         else {
+            const panelEndTime = guildDoc.quotas.panelEndTime ?? null;
+            
             if (panelEndTime) {
                 const endDisplay = TimeUtilities.getDiscordTime({
                     time: panelEndTime,


### PR DESCRIPTION
Allows the configQuota command to choose "never" instead of a day of the week, and doing so will make it never reset automatically. 

There is also a button called "Set Panel End Date" and this sets the Guild-Wide quota panel end dates. (its done in YYYY-MM-DD, and you can set HH:MM optionally.

This was tested and seems to work fine as far as I can tell!